### PR TITLE
  v0.1.3 リリース: バージョン更新と Homebrew Formula 更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "cliip-show"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "objc2",
  "objc2-app-kit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cliip-show"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]

--- a/Formula/cliip-show.rb
+++ b/Formula/cliip-show.rb
@@ -1,8 +1,8 @@
 class CliipShow < Formula
   desc "Show copied clipboard text as a HUD on macOS"
   homepage "https://github.com/somei-san/cliip-show"
-  url "https://github.com/somei-san/cliip-show/archive/refs/tags/v0.1.2.tar.gz"
-  sha256 "d780782bc229bc3068c44503fd834439d22ef9f766ebd52ab4051fd9ecd25164"
+  url "https://github.com/somei-san/cliip-show/archive/refs/tags/v0.1.3.tar.gz"
+  sha256 "7f50604edd8e39d46adf45c3b5340a3d4006d04de4750910bee685e71c4255e6"
   license "MIT"
   head "https://github.com/somei-san/cliip-show.git", branch: "main"
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -151,11 +151,7 @@ git push origin v0.1.1
 
 タグのバージョンは `Cargo.toml` の `version` と同じ値にしてください（例: `0.1.1` -> `v0.1.1`）。
 
-### 3. Homebrew tap リポジトリ
-
-<https://github.com/somei-san/homebrew-tools>
-
-### 4. Formulaを生成する
+### 3. Formulaを生成する
 
 このリポジトリで以下を実行します。
 
@@ -165,10 +161,10 @@ git push origin v0.1.1
 
 バージョンは `0.1.1` のように `v` なしで指定してください（タグは内部で `v0.1.1` として参照されます）。
 
-生成された `Formula/cliip-show.rb` を [tap リポジトリ](https://github.com/somei-san/homebrew-tools) の `Formula/cliip-show.rb` としてコミットして push してください。
+生成された `Formula/cliip-show.rb` を [Homebrew tap リポジトリ](https://github.com/somei-san/homebrew-tools) の `Formula/cliip-show.rb` としてコミットして push してください。
 
 テンプレートは `packaging/homebrew/cliip-show.rb.template` にあります。
 
-### 5. ユーザーのインストール手順
+### 4. ユーザーのインストール手順
 
 [TapリポジトリのREADME参照](https://github.com/somei-san/homebrew-tools/blob/main/README.md)


### PR DESCRIPTION
  ## 概要
  v0.1.3 のリリース準備として、バージョン番号と Homebrew Formula を更新しました。

  ## 変更内容
  - `Cargo.toml` の `version` を `0.1.2 -> 0.1.3` に更新
  - `Cargo.lock` を同期更新
  - `Formula/cliip-show.rb` を `v0.1.3` 向けに更新
    - archive URL を `v0.1.3` に変更
    - SHA256 を更新
  - `docs/development.md` の軽微な整備

  ## 差分ファイル
  - `Cargo.toml`
  - `Cargo.lock`
  - `Formula/cliip-show.rb`
  - `docs/development.md`

  ## 確認
  - `cargo test` 実行済み（全テスト成功）
  - `scripts/homebrew/generate_formula.sh somei-san 0.1.3 ./Formula/cliip-show.rb` で
  Formula 生成済み

  ## 補足
  - タグ `v0.1.3` は作成・push 済みです。