### PR TITLE
Claude Code のフックと CI の lint ジョブを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,19 @@
 {
   "allowedPaths": [
     ".dojo/"
-  ]
+  ],
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *.rs) rustfmt --edition 2021 \"$f\";; esac; } || true",
+            "statusMessage": "rustfmt"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.claude/skills/vrt-update/SKILL.md
+++ b/.claude/skills/vrt-update/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: vrt-update
+description: VRT を実行し、閾値を超えたケースを提示してから baseline を更新する
+disable-model-invocation: true
+---
+
+# VRT baseline 更新
+
+`./scripts/visual_regression.sh --update` は全ケースの baseline を一括で上書きする。意図しない HUD 変更まで baseline に焼き付けないよう、更新前に差分の中身を人が見る。
+
+## 手順
+
+1. 判定だけを実行する。
+
+   ```bash
+   ./scripts/visual_regression.sh
+   ```
+
+2. 出力から `ng:` のケースを拾い、ケース ID・`pixels` 比・diff PNG のパスを一覧にしてユーザーに示す。全ケースが `ok:` なら baseline は既に一致しているので、ここで終了する。
+
+3. diff PNG（`tests/visual/artifacts/<id>.diff.png`）と現行 PNG（`tests/visual/artifacts/<id>.current.png`）を Read で開き、差分が意図した UI 変更かを述べる。
+
+4. 「baseline を更新しますか？ (Y/n)」で確認する。承認されるまで更新しない。
+
+5. 承認されたら更新し、再実行して `visual regression passed` になることを確かめる。
+
+   ```bash
+   ./scripts/visual_regression.sh --update
+   ./scripts/visual_regression.sh
+   ```
+
+## 注意
+
+- 更新は全ケース一括。特定ケースだけを更新する経路はスクリプトに無いので、`ng` 以外のケースにも差分が無いことを手順 2 で確認してから進める。
+- 許容差は環境変数 `MAX_DIFF_PERMILLE`（既定 120/1000）。許容内の揺れは `ok` になり baseline 更新の対象にならない。

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -7,6 +7,19 @@ on:
       - main
 
 jobs:
+  # objc2 のコードは macOS でしか型検査が通らないため clippy も macos-latest で回す
+  lint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
   visual-regression:
     runs-on: macos-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # cliip-show 開発ガイド
 
+macOS 専用（objc2 / AppKit 依存で `cargo test` も macOS でのみ通る）。
+開発起動・`.app` 化・メニューアイコン生成・VRT の生成物と判定ルール・Homebrew 公開手順は `docs/development.md` にある。
+
 ## テスト
 
 コードを変更したあとは **UT と VRT と lint** を必ず確認すること。いずれも CI のゲートになっている。
@@ -16,12 +19,16 @@ cargo fmt --check
 cargo clippy --all-targets -- -D warnings
 ```
 
+HUD を実機で見るなら `./scripts/local_check.sh`（オプションは `docs/development.md`）。
+
 ### 運用ルール
 - 通常の変更: 上記3つがすべて通ることを確認してからPRを出す
 - 意図したUI変更（HUD外観の変更など）: VRTのベースラインを更新する
   ```bash
   ./scripts/visual_regression.sh --update
   ```
+- VRT が撮るのは HUD の contentView だけ。設定ウィンドウとメニューバーは対象外
+- VRT のケースは `CLIIP_SHOW_*` 環境変数で設定を上書きして作る（`scripts/visual_regression.sh` の `run_case`）
 - `Cargo.toml` の `edition` を変えたら `.claude/settings.json` の rustfmt フック（`--edition` を直書き）も同期する。ズレるとフックの整形結果を CI の `cargo fmt --check` が拒否する
 
 ## モジュール構成
@@ -44,6 +51,6 @@ cargo clippy --all-targets -- -D warnings
 
 ## リリース
 
-`v*` タグの push で `release.yml` が GitHub Release の作成と [somei-san/homebrew-tap](https://github.com/somei-san/homebrew-tap) の Formula 更新まで行う。
+`./scripts/release.sh <version>` でバージョン更新から `v*` タグの push までを行う。タグを起点に `release.yml` が GitHub Release の作成と [somei-san/homebrew-tap](https://github.com/somei-san/homebrew-tap) の Formula 更新まで実行する。
 
 Formula は `packaging/homebrew/cliip-show.rb.template` から自動生成されるが、tap の README は手書きなので追随しない。起動方法・設定コマンド・スクリーンショットを変えたら tap の README も更新すること。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## テスト
 
-コードを変更したあとは **UT と VRT の両方** を必ず確認すること。
+コードを変更したあとは **UT と VRT と lint** を必ず確認すること。いずれも CI のゲートになっている。
 
 ```bash
 # UT（ユニットテスト）
@@ -10,24 +10,33 @@ cargo test
 
 # VRT（ビジュアルリグレッションテスト）
 ./scripts/visual_regression.sh
+
+# lint（CI と同じ条件）
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
 ```
 
 ### 運用ルール
-- 通常の変更: 上記2つがすべて通ることを確認してからPRを出す
+- 通常の変更: 上記3つがすべて通ることを確認してからPRを出す
 - 意図したUI変更（HUD外観の変更など）: VRTのベースラインを更新する
   ```bash
   ./scripts/visual_regression.sh --update
   ```
+- `Cargo.toml` の `edition` を変えたら `.claude/settings.json` の rustfmt フック（`--edition` を直書き）も同期する。ズレるとフックの整形結果を CI の `cargo fmt --check` が拒否する
 
 ## モジュール構成
 
 | ファイル | 役割 |
 |---|---|
 | `src/main.rs` | エントリポイント（`fn main` のみ） |
+| `src/lib.rs` | モジュール宣言 |
 | `src/cli.rs` | CLIフラグの処理（`--help`, `--config`, `--render-hud-png` など） |
-| `src/config.rs` | 設定の型・読み書き・パース・`--config` サブコマンド |
+| `src/config/` | 設定（`types.rs` 型 / `parse.rs` パース / `io.rs` 読み書き / `settings.rs` 項目定義 / `cli.rs` `--config` サブコマンド） |
 | `src/hud.rs` | HUDウィンドウ生成・レイアウト計算・描画 |
 | `src/app.rs` | AppDelegate・クリップボード監視・フェードアニメーション |
+| `src/menu.rs` | メニューバー常駐アイコンとメインメニューの構築 |
+| `src/settings_window.rs` | 設定ウィンドウのUI |
+| `src/login_item.rs` | LaunchAgent の plist 書き出し・解除（自動起動） |
 | `src/text.rs` | テキスト切り詰め処理 |
 | `src/png.rs` | PNG生成・差分計算（VRT用） |
 | `src/objc_helpers.rs` | NSString変換ユーティリティ |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,9 @@ cargo clippy --all-targets -- -D warnings
 | `src/png.rs` | PNG生成・差分計算（VRT用） |
 | `src/objc_helpers.rs` | NSString変換ユーティリティ |
 | `src/error.rs` | `AppError` 型定義 |
+
+## リリース
+
+`v*` タグの push で `release.yml` が GitHub Release の作成と [somei-san/homebrew-tap](https://github.com/somei-san/homebrew-tap) の Formula 更新まで行う。
+
+Formula は `packaging/homebrew/cliip-show.rb.template` から自動生成されるが、tap の README は手書きなので追随しない。起動方法・設定コマンド・スクリーンショットを変えたら tap の README も更新すること。

--- a/src/hud.rs
+++ b/src/hud.rs
@@ -625,7 +625,7 @@ mod tests {
     fn fit_thumbnail_size_keeps_aspect_ratio_when_shrinking() {
         let (width, height) = fit_thumbnail_size(320.0, 180.0, 100, 1.0, true);
         assert_eq!(height, 100.0);
-        assert_eq!(width, (320.0 * (100.0 / 180.0) as f64).round());
+        assert_eq!(width, (320.0_f64 * (100.0 / 180.0)).round());
     }
 
     #[test]
@@ -683,7 +683,7 @@ mod tests {
 
     #[test]
     fn hud_width_regression_snapshot() {
-        let cases = vec![
+        let cases = [
             ("ascii_short", "hello".to_string()),
             ("ascii_40", "a".repeat(40)),
             ("wide_20", "あ".repeat(20)),


### PR DESCRIPTION
## 概要

`cargo fmt --check` と `cargo clippy` を CI のゲートに加えます。あわせて、同じ整形をローカルの編集時に効かせる Claude Code のフックと、VRT の baseline 更新を差分確認付きにするスキルをリポジトリに置きます。

## 変更内容

- Claude Code のフック（`.claude/settings.json`）— `*.rs` を編集したら rustfmt を走らせます。編集ファイルの絶対パスを rustfmt に直接渡すので cwd に依存しません。`--edition` は直書きなので `Cargo.toml` と同期が要ります
- `/vrt-update` スキル（`.claude/skills/vrt-update/SKILL.md`）— `visual_regression.sh --update` は全ケースの baseline を一括で上書きするため、差分を確認してから更新させます。ユーザー起動専用（`disable-model-invocation: true`）です
- CI（`.github/workflows/visual-regression.yml`）— `cargo fmt --check` と `cargo clippy --all-targets -- -D warnings` を `lint` ジョブとして追加します。VRT ジョブに同居させると lint 失敗で VRT が走らなくなるため分けています。objc2 のコードは macOS でしか型検査が通らないので `macos-latest` です
- `src/hud.rs` — clippy を `-D warnings` で通すため、テストの `vec!` と不要な `f64` キャストを落とします。期待値は変わりません
- `CLAUDE.md`
  - 冒頭 — macOS 専用であることと `docs/development.md` への導線を足します
  - テスト手順 — lint と実機確認（`local_check.sh`）を追加します
  - モジュール構成表 — `src/config/` の分割と `lib.rs` / `menu.rs` / `settings_window.rs` / `login_item.rs` に合わせます
  - VRT の適用範囲 — HUD の contentView だけが対象で、設定ウィンドウとメニューバーは含まれないことを書きます
  - リリース節 — 新設し、`release.sh` を入口として示します。tap の README は Formula と違って自動更新されないことも書きます

## 確認

- `cargo test`（45 件）
- `./scripts/visual_regression.sh`（34 ケース）
- `cargo fmt --check` と `cargo clippy --all-targets -- -D warnings`
- フックの発火 — `src/text.rs` の書式を崩して編集し、差分ゼロに復元されることを確認

## 補足

- rustfmt は `mod` 宣言をたどるため、`src/lib.rs` を編集するとクレート全体が整形対象になります。回避する `--skip-children` は stable の rustfmt では使えません
- toolchain は `dtolnay/rust-toolchain@stable` なので、新しい lint が入ると変更と無関係に `-D warnings` で落ちることがあります
- ワークフロー名は `visual-regression` のままで、`lint` ジョブが同居します
