### PR TITLE
local_check.sh が常駐インスタンスを止めっぱなしにする不具合を直す

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -23,7 +23,7 @@ cargo run
 
 ```bash
 ./scripts/local_check.sh --position bottom --scale 1.5 --color red
-./scripts/local_check.sh --no-stop-brew --no-build
+./scripts/local_check.sh --no-stop-installed --no-build
 ```
 
 このスクリプトは検証用configを `/tmp/cliip-show-local-check.toml` に作成し、`Ctrl+C` で終了できます。

--- a/scripts/local_check.sh
+++ b/scripts/local_check.sh
@@ -14,7 +14,7 @@ Options:
   --color <default|yellow|blue|green|red|purple>      HUD background color (optional; default uses app config default)
   --text <TEXT>                                        Clipboard text to copy after startup
   --config-path <PATH>                                 Temp config path (default: /tmp/cliip-show-local-check.toml)
-  --no-stop-brew                                       Do not stop `brew services cliip-show`
+  --no-stop-installed                                  Leave the installed cliip-show running (HUD may appear twice)
   --no-build                                           Skip `cargo build`
   --no-copy                                            Do not auto-copy test text
   -h, --help                                           Show this help
@@ -49,7 +49,7 @@ COLOR_EXPLICIT=false
 TEXT="${LOCAL_CHECK_TEXT:-}"
 TEXT_EXPLICIT=false
 CONFIG_PATH="${LOCAL_CHECK_CONFIG_PATH:-/tmp/cliip-show-local-check.toml}"
-STOP_BREW=true
+STOP_INSTALLED=true
 DO_BUILD=true
 AUTO_COPY=true
 
@@ -97,8 +97,8 @@ while [[ $# -gt 0 ]]; do
       CONFIG_PATH="$2"
       shift 2
       ;;
-    --no-stop-brew)
-      STOP_BREW=false
+    --no-stop-installed)
+      STOP_INSTALLED=false
       shift
       ;;
     --no-build)
@@ -159,10 +159,36 @@ if ! $TEXT_EXPLICIT; then
   fi
 fi
 
-if $STOP_BREW && command -v brew >/dev/null 2>&1; then
-  echo "[local_check] stopping brew service: cliip-show"
-  brew services stop cliip-show >/dev/null 2>&1 || true
+# 常駐中のインストール済みインスタンスを止める。HUD が二重に出ると、どちらの見た目を
+# 見ているのか分からなくなるため。止めた場合は終了時に元の起動状態へ戻す。
+LOGIN_ITEM_LABEL="io.github.somei-san.cliip-show"
+LOGIN_ITEM_PLIST="$HOME/Library/LaunchAgents/$LOGIN_ITEM_LABEL.plist"
+LOGIN_ITEM_DOMAIN="gui/$(id -u)"
+INSTALLED_BIN="$(command -v cliip-show 2>/dev/null || true)"
+RESTORE_LOGIN_ITEM=false
+RESTORE_INSTALLED_BIN=false
+
+if $STOP_INSTALLED; then
+  if launchctl print "$LOGIN_ITEM_DOMAIN/$LOGIN_ITEM_LABEL" >/dev/null 2>&1; then
+    echo "[local_check] stopping login item: $LOGIN_ITEM_LABEL"
+    launchctl bootout "$LOGIN_ITEM_DOMAIN/$LOGIN_ITEM_LABEL" >/dev/null 2>&1 || true
+    RESTORE_LOGIN_ITEM=true
+  elif [[ -n "$INSTALLED_BIN" ]] && pgrep -xf "$INSTALLED_BIN" >/dev/null 2>&1; then
+    echo "[local_check] stopping running instance: $INSTALLED_BIN"
+    pkill -xf "$INSTALLED_BIN" >/dev/null 2>&1 || true
+    RESTORE_INSTALLED_BIN=true
+  fi
 fi
+
+restore_installed() {
+  if $RESTORE_LOGIN_ITEM && [[ -f "$LOGIN_ITEM_PLIST" ]]; then
+    echo "[local_check] restoring login item: $LOGIN_ITEM_LABEL"
+    launchctl bootstrap "$LOGIN_ITEM_DOMAIN" "$LOGIN_ITEM_PLIST" >/dev/null 2>&1 || true
+  elif $RESTORE_INSTALLED_BIN && [[ -n "$INSTALLED_BIN" ]]; then
+    echo "[local_check] restarting: $INSTALLED_BIN"
+    "$INSTALLED_BIN" >/dev/null 2>&1 &
+  fi
+}
 
 if $DO_BUILD; then
   echo "[local_check] cargo build"
@@ -193,10 +219,18 @@ fi
 CLIIP_SHOW_CONFIG_PATH="$CONFIG_PATH" "$BIN" --config show
 
 APP_PID=""
+# trap は TERM で発火したあと EXIT でも発火するため、復帰処理が二度走らないよう塞ぐ。
+# 二度走るとインストール済みインスタンスが二重起動する。
+CLEANUP_DONE=false
 cleanup() {
+  if $CLEANUP_DONE; then
+    return
+  fi
+  CLEANUP_DONE=true
   if [[ -n "$APP_PID" ]]; then
     kill "$APP_PID" >/dev/null 2>&1 || true
   fi
+  restore_installed
 }
 trap cleanup EXIT INT TERM
 


### PR DESCRIPTION
## 概要

`local_check.sh` は brew サービスとしての常駐だけを対象に「実行前に止めて終了時に戻す」処理をしていました。現在の常駐手段は LaunchAgent（ログイン項目）または `cliip-show` の直接起動で、brew サービス化はもう使っていないため、この処理が事実上ずっと働いていませんでした。実行中に常駐インスタンスとローカルビルドの HUD が二重に出て、どちらの見た目を見ているのか分からなくなります。

## 変更内容

- `--no-stop-brew` を `--no-stop-installed` に変更 — 対象を LaunchAgent と直接起動プロセスに広げたのに合わせて名前も揃えます
- 実行前の停止対象を LaunchAgent（`launchctl bootout`）→ 直接起動プロセス（`pkill -xf`）の順で判定するように変更 — どちらの常駐方式でも二重表示を防ぎます
- 終了時に元の起動状態へ戻す処理（`restore_installed`）を追加
- `trap cleanup EXIT INT TERM` が TERM 受信後に EXIT でも発火して復帰処理が二重に走り、直接起動プロセスが二重起動する問題を、フラグで一度きりに制限して修正

## 確認

- `cargo test`
- `./scripts/visual_regression.sh`
- `cargo fmt --check` と `cargo clippy --all-targets -- -D warnings`
- macOS 実機で以下を確認
  - LaunchAgent 読み込み済みの状態で実行 → 実行中は止まり、終了後に LaunchAgent 経由で 1 つだけ復帰する
  - 直接起動のみの状態で実行 → 実行中は止まり、終了後にプロセスが 1 つだけ復帰する
  - どちらも動いていない状態で実行 → 停止・復帰とも走らず、終了後も何も残らない