### PR TITLE
local_check.sh で自動起動トグルを触らないよう警告する

### DIFF
--- a/scripts/local_check.sh
+++ b/scripts/local_check.sh
@@ -234,6 +234,10 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+# 設定ウィンドウの自動起動トグルだけは $CONFIG_PATH ではなく $HOME の LaunchAgent を読み書きする。
+# ここで触ると開発ビルドのパスを指す plist が書かれ、cargo clean でインストール済みアプリの
+# 自動起動ごと壊れる。
+echo "[local_check] warning: do not touch the login item toggle; it overwrites the installed app's LaunchAgent"
 echo "[local_check] starting cliip-show (Ctrl+C to stop)"
 CLIIP_SHOW_CONFIG_PATH="$CONFIG_PATH" "$BIN" &
 APP_PID="$!"


### PR DESCRIPTION
## 背景

設定ウィンドウの自動起動トグルは、設定ファイルと違って `CLIIP_SHOW_CONFIG_PATH` の影響を受けない。`$HOME/Library/LaunchAgents` の plist を直接読み書きするため、`local_check.sh` で起動した開発ビルドから触ると plist がリポジトリ配下のパスを指し、`cargo clean` でインストール済みアプリの自動起動ごと壊れる。

アプリ側で `enable()` を拒む案は採らない。踏めるのはリポジトリを持つ開発者だけで、実行パスから開発ビルドを判定するコードを製品バイナリに載せると、インストール先を誤判定して実ユーザーの自動起動を塞ぐ経路ができる。

## 変更内容

- `local_check.sh` — 起動メッセージの直前に、自動起動トグルを触るとインストール済みアプリの LaunchAgent を上書きすると警告する

## 確認

- `cargo test`（51 件）
- `./scripts/visual_regression.sh`（34 ケース）
- `cargo fmt --check` と `cargo clippy --all-targets -- -D warnings`
- `shellcheck scripts/local_check.sh`
- 実機で `local_check.sh` を起動し、警告が起動メッセージの直前に出ること、終了後に開発ビルドが残らずインストール済みインスタンスと LaunchAgent が無事なことを確認

## 関連リンク

- Issue: #19
- 方針の記録と残る一般形の問題: https://github.com/somei-san/cliip-show/issues/19#issuecomment-5300764835
