### PR TITLE
CLI からの設定変更をなくして設定ウィンドウに一本化する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ UI 文言を README に書くときは `src/i18n.rs` の文言テーブルと一
 |---|---|
 | `src/main.rs` | エントリポイント（`fn main` のみ） |
 | `src/lib.rs` | モジュール宣言 |
-| `src/cli.rs` | CLIフラグの処理（`--help`, `--config`, `--render-hud-png` など） |
-| `src/config/` | 設定（`types.rs` 型 / `parse.rs` パース / `io.rs` 読み書き / `settings.rs` 項目定義 / `cli.rs` `--config` サブコマンド） |
+| `src/cli.rs` | CLIフラグの処理（`--help`, `--config-show`, `--render-hud-png` など） |
+| `src/config/` | 設定（`types.rs` 型 / `parse.rs` パース / `io.rs` 読み書き / `settings.rs` 項目定義 / `cli.rs` `--config-show` の出力） |
 | `src/hud.rs` | HUDウィンドウ生成・レイアウト計算・描画 |
 | `src/app.rs` | AppDelegate・クリップボード監視・フェードアニメーション |
 | `src/menu.rs` | メニューバー常駐アイコンとメインメニューの構築 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -48,7 +48,7 @@ cliip-show
 
 ## 表示設定
 
-メニューバーの「設定…」から設定ウィンドウを開いて変更できます。`--config set`と同じ設定ファイルを読み書きします。
+メニューバーの「設定…」から設定ウィンドウを開いて変更します。設定を変更する手段はこれだけです。
 
 設定ウィンドウでの変更はその場では保存されず、下部のボタンで確定します。
 - 保存: 変更をファイルに書き込み、HUDにも反映します（Enterキーでも実行できます）
@@ -59,26 +59,12 @@ cliip-show
 
 「言語」と「ログイン時に自動起動」だけは上記の下書き・保存モデルに乗らず、変更した瞬間に反映します。「デフォルトに戻す」の対象外なのもこの2つだけです。「ログイン時に自動起動」はOSのログイン項目の設定なので、設定ファイルには保存しません。
 
-### コマンドラインから
+### 設定ファイルと環境変数
 
-初期化と確認:
-
-```bash
-cliip-show --config init
-cliip-show --config show
-```
-
-設定値を保存:
+現在の設定値を表示する:
 
 ```bash
-cliip-show --config set hud_duration_secs 2.5
-cliip-show --config set hud_fade_duration_secs 0.5
-cliip-show --config set max_lines 3
-cliip-show --config set hud_position top
-cliip-show --config set hud_scale 1.2
-cliip-show --config set hud_background_color blue
-cliip-show --config set hud_emoji 🍣
-cliip-show --config set hud_image_max_height 120
+cliip-show --config-show
 ```
 
 設定キー:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can switch that on and off any time from "Start at login" in the settings wi
 
 ## Settings
 
-Open the settings window from "Settings…" in the menu bar. It reads and writes the same file as `--config set`.
+Open the settings window from "Settings…" in the menu bar. It is the only way to change settings.
 
 Changes are not saved as you make them. The buttons at the bottom decide what happens:
 - Save: writes the changes to the file and applies them to the HUD (Enter does the same)
@@ -57,26 +57,12 @@ Closing the window without saving goes back to what is in the file.
 
 "Language" and "Start at login" work differently: both take effect the moment you change them, and neither is touched by "Restore Defaults". "Start at login" is an OS-level setting and is not written to the config file.
 
-### From the command line
+### Config file and environment variables
 
-Initialize and inspect:
-
-```bash
-cliip-show --config init
-cliip-show --config show
-```
-
-Set a value:
+Print what is currently in effect:
 
 ```bash
-cliip-show --config set hud_duration_secs 2.5
-cliip-show --config set hud_fade_duration_secs 0.5
-cliip-show --config set max_lines 3
-cliip-show --config set hud_position top
-cliip-show --config set hud_scale 1.2
-cliip-show --config set hud_background_color blue
-cliip-show --config set hud_emoji 🍣
-cliip-show --config set hud_image_max_height 120
+cliip-show --config-show
 ```
 
 Keys:

--- a/scripts/local_check.sh
+++ b/scripts/local_check.sh
@@ -202,21 +202,23 @@ if [[ ! -x "$BIN" ]]; then
 fi
 
 echo "[local_check] config path: $CONFIG_PATH"
-rm -f "$CONFIG_PATH"
-CLIIP_SHOW_CONFIG_PATH="$CONFIG_PATH" "$BIN" --config init >/dev/null
+# 上書きは環境変数ではなく設定ファイルに書く。環境変数は設定ファイルより優先されるため、
+# 設定ウィンドウで保存してもウィンドウを閉じた時点で環境変数の値に戻り、ウィンドウの
+# 動作確認ができなくなる。書かなかった項目はアプリの既定値になる。
+printf '[display]\n' > "$CONFIG_PATH"
 if $POSITION_EXPLICIT; then
-  CLIIP_SHOW_CONFIG_PATH="$CONFIG_PATH" "$BIN" --config set hud_position "$POSITION" >/dev/null
+  printf 'hud_position = "%s"\n' "$POSITION" >> "$CONFIG_PATH"
 fi
 if $SCALE_EXPLICIT; then
-  CLIIP_SHOW_CONFIG_PATH="$CONFIG_PATH" "$BIN" --config set hud_scale "$SCALE" >/dev/null
+  printf 'hud_scale = %s\n' "$SCALE" >> "$CONFIG_PATH"
 fi
 if $COLOR_EXPLICIT; then
-  CLIIP_SHOW_CONFIG_PATH="$CONFIG_PATH" "$BIN" --config set hud_background_color "$COLOR" >/dev/null
+  printf 'hud_background_color = "%s"\n' "$COLOR" >> "$CONFIG_PATH"
 fi
 if ! $POSITION_EXPLICIT && ! $SCALE_EXPLICIT && ! $COLOR_EXPLICIT; then
   echo "[local_check] using app default display settings (no overrides)"
 fi
-CLIIP_SHOW_CONFIG_PATH="$CONFIG_PATH" "$BIN" --config show
+CLIIP_SHOW_CONFIG_PATH="$CONFIG_PATH" "$BIN" --config-show
 
 APP_PID=""
 # trap は TERM で発火したあと EXIT でも発火するため、復帰処理が二度走らないよう塞ぐ。

--- a/src/app.rs
+++ b/src/app.rs
@@ -352,8 +352,8 @@ pub(crate) unsafe fn apply_settings_now(state: &mut AppState, new_settings: Disp
     state.settings = new_settings;
 
     // language が変わったら設定ウィンドウとメニューの文言を即時更新。
-    // ファイル監視の再読み込み・`--config set language`・設定ウィンドウの言語ポップアップの
-    // いずれの経路もここを通るため、更新箇所は一箇所で済む。
+    // ファイル監視の再読み込みと設定ウィンドウの言語ポップアップのどちらの経路もここを
+    // 通るため、更新箇所は一箇所で済む。
     //
     // ここで触るのは非編集ラベルと NSButton/NSMenuItem/NSMenu/NSWindow のタイトルだけで
     // action もテキスト編集のデリゲート通知も発火しないため、APP_STATE のロックを

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 
-use crate::config::handle_config_command;
+use crate::config::show_config;
 use crate::png::{generate_diff_png, render_hud_image_png, render_hud_png};
 
 /// `--image-fixture` の `<W>x<H>` をパースする。
@@ -48,49 +48,16 @@ pub fn handle_cli_flags() -> bool {
             );
             let _ = writeln!(
                 help,
-                "  --config <path|show|init|set ...>    Manage persistent settings file"
+                "  --config-show    Print the current settings and exit"
             );
             let _ = writeln!(help);
-            let _ = writeln!(help, "Config commands (persistent settings):");
-            let _ = writeln!(help, "  cliip-show --config init");
-            let _ = writeln!(help, "  cliip-show --config init --force");
-            let _ = writeln!(help, "  cliip-show --config show");
-            let _ = writeln!(help, "  cliip-show --config set hud_duration_secs 2.5");
-            let _ = writeln!(help, "  cliip-show --config set max_lines 3");
-            let _ = writeln!(help, "  cliip-show --config set hud_position top");
-            let _ = writeln!(help, "  cliip-show --config set hud_scale 1.2");
-            let _ = writeln!(help, "  cliip-show --config set hud_background_color blue");
-            let _ = writeln!(help, "  cliip-show --config set hud_emoji 🍣");
-            let _ = writeln!(help, "  cliip-show --config set hud_image_max_height 120");
-            let _ = writeln!(help);
-            let _ = writeln!(help, "Config keys:");
-            let _ = writeln!(help, "  poll_interval_secs      default=0.3 (0.05 - 5.0)");
-            let _ = writeln!(help, "  hud_duration_secs       default=1.0 (0.1 - 10.0)");
-            let _ = writeln!(help, "  hud_fade_duration_secs  default=0.3 (0.0 - 2.0)");
-            let _ = writeln!(help, "  max_chars_per_line      default=100 (1 - 500)");
-            let _ = writeln!(help, "  max_lines               default=5 (1 - 20)");
             let _ = writeln!(
                 help,
-                "  hud_position            default=top (top|center|bottom)"
-            );
-            let _ = writeln!(help, "  hud_scale               default=1.1 (0.5 - 2.0)");
-            let _ = writeln!(
-                help,
-                "  hud_background_color    default=default (default|yellow|blue|green|red|purple)"
+                "Settings are edited in the settings window (\"Settings…\" in the menu bar)."
             );
             let _ = writeln!(
                 help,
-                "  hud_emoji               default=📋 (any single emoji; empty for no icon)"
-            );
-            let _ = writeln!(
-                help,
-                "  hud_image_max_height    default=160 (40 - 240)  note: scaled by hud_scale"
-            );
-            let _ = writeln!(help, "  language                default=auto (auto|ja|en)");
-            let _ = writeln!(help);
-            let _ = writeln!(
-                help,
-                "Note: config changes are hot-reloaded automatically (no restart needed)."
+                "Changes are hot-reloaded automatically (no restart needed)."
             );
             let _ = writeln!(help);
             let _ = writeln!(help, "Persistent config file:");
@@ -108,6 +75,10 @@ pub fn handle_cli_flags() -> bool {
             let _ = writeln!(
                 help,
                 "  CLIIP_SHOW_HUD_DURATION_SECS    HUD visible seconds (0.1 - 10.0)"
+            );
+            let _ = writeln!(
+                help,
+                "  CLIIP_SHOW_HUD_FADE_DURATION_SECS  HUD fade seconds (0.0 - 2.0; 0.0 disables)"
             );
             let _ = writeln!(
                 help,
@@ -144,7 +115,7 @@ pub fn handle_cli_flags() -> bool {
             print!("{help}");
             true
         }
-        "--config" => handle_config_command(&mut args),
+        "--config-show" => show_config(&mut args),
         "--render-hud-png" => {
             let mut text: Option<String> = None;
             let mut image_fixture: Option<(usize, usize)> = None;

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -1,11 +1,16 @@
-use super::io::{config_file_path, load_config_file, save_config_file};
-use super::parse::{parse_config_key, set_config_value};
+use super::io::{config_file_path, load_config_file};
 use super::settings::{
     apply_config_file, apply_env_overrides, default_display_settings, print_effective_settings,
-    settings_to_config_file,
 };
 
-pub fn handle_config_command<I: Iterator<Item = String>>(args: &mut I) -> bool {
+/// `--config-show` の処理。設定の変更手段は設定ウィンドウに一本化しているため、
+/// CLI からは現在値の確認だけできる。不具合の切り分けに使う。
+pub fn show_config<I: Iterator<Item = String>>(args: &mut I) -> bool {
+    if args.next().is_some() {
+        eprintln!("Usage: cliip-show --config-show");
+        std::process::exit(2);
+    }
+
     let path = match config_file_path() {
         Ok(path) => path,
         Err(error) => {
@@ -13,163 +18,53 @@ pub fn handle_config_command<I: Iterator<Item = String>>(args: &mut I) -> bool {
             std::process::exit(1);
         }
     };
-    let Some(cmd) = args.next() else {
-        eprintln!("Usage: cliip-show --config <path|show|init|set>");
-        std::process::exit(2);
+
+    println!("config_path = {}", path.display());
+    let (config, loaded_from_file) = match load_config_file(&path) {
+        Ok(result) => result,
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(1);
+        }
     };
-
-    match cmd.as_str() {
-        "path" => {
-            if args.next().is_some() {
-                eprintln!("Usage: cliip-show --config path");
-                std::process::exit(2);
-            }
-            println!("{}", path.display());
-            true
+    if loaded_from_file {
+        println!("config_file = exists");
+        println!("[saved]");
+        if let Some(value) = config.display.poll_interval_secs {
+            println!("poll_interval_secs = {}", value);
         }
-        "show" => {
-            if args.next().is_some() {
-                eprintln!("Usage: cliip-show --config show");
-                std::process::exit(2);
-            }
-            println!("config_path = {}", path.display());
-            let (config, loaded_from_file) = match load_config_file(&path) {
-                Ok(result) => result,
-                Err(error) => {
-                    eprintln!("{error}");
-                    std::process::exit(1);
-                }
-            };
-            if loaded_from_file {
-                println!("config_file = exists");
-                println!("[saved]");
-                if let Some(value) = config.display.poll_interval_secs {
-                    println!("poll_interval_secs = {}", value);
-                }
-                if let Some(value) = config.display.hud_duration_secs {
-                    println!("hud_duration_secs = {}", value);
-                }
-                if let Some(value) = config.display.hud_fade_duration_secs {
-                    println!("hud_fade_duration_secs = {}", value);
-                }
-                if let Some(value) = config.display.max_chars_per_line {
-                    println!("max_chars_per_line = {}", value);
-                }
-                if let Some(value) = config.display.max_lines {
-                    println!("max_lines = {}", value);
-                }
-                if let Some(value) = config.display.hud_position {
-                    println!("hud_position = {}", value.as_str());
-                }
-                if let Some(value) = config.display.hud_scale {
-                    println!("hud_scale = {}", value);
-                }
-                if let Some(value) = config.display.hud_background_color {
-                    println!("hud_background_color = {}", value.as_str());
-                }
-                if let Some(value) = &config.display.hud_emoji {
-                    println!("hud_emoji = {}", value);
-                }
-                if let Some(value) = config.display.language {
-                    println!("language = {}", value.as_str());
-                }
-            } else {
-                println!("config_file = not_found");
-            }
-            println!("[effective]");
-            let effective =
-                apply_env_overrides(apply_config_file(default_display_settings(), &config));
-            print_effective_settings(effective);
-            true
+        if let Some(value) = config.display.hud_duration_secs {
+            println!("hud_duration_secs = {}", value);
         }
-        "init" => {
-            let mut force = false;
-            if let Some(arg) = args.next() {
-                if arg == "--force" {
-                    force = true;
-                    if args.next().is_some() {
-                        eprintln!("Usage: cliip-show --config init [--force]");
-                        std::process::exit(2);
-                    }
-                } else {
-                    eprintln!("Usage: cliip-show --config init [--force]");
-                    std::process::exit(2);
-                }
-            }
-
-            if !force && path.exists() {
-                eprintln!(
-                    "config file already exists: {} (use --force to overwrite)",
-                    path.display()
-                );
-                std::process::exit(2);
-            }
-
-            let config = settings_to_config_file(default_display_settings());
-            if let Err(error) = save_config_file(&path, &config) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-            println!("initialized config: {}", path.display());
-            true
+        if let Some(value) = config.display.hud_fade_duration_secs {
+            println!("hud_fade_duration_secs = {}", value);
         }
-        "set" => {
-            let Some(key_raw) = args.next() else {
-                eprintln!("Usage: cliip-show --config set <key> <value>");
-                eprintln!(
-                    "Available keys: poll_interval_secs, hud_duration_secs, hud_fade_duration_secs, max_chars_per_line, max_lines, hud_position, hud_scale, hud_background_color, hud_emoji, language"
-                );
-                std::process::exit(2);
-            };
-            let Some(value_raw) = args.next() else {
-                eprintln!("Usage: cliip-show --config set <key> <value>");
-                std::process::exit(2);
-            };
-            if args.next().is_some() {
-                eprintln!("Usage: cliip-show --config set <key> <value>");
-                std::process::exit(2);
-            }
-            let Some(key) = parse_config_key(key_raw.trim()) else {
-                eprintln!(
-                    "Unknown key: {key_raw}. Available keys: poll_interval_secs, hud_duration_secs, hud_fade_duration_secs, max_chars_per_line, max_lines, hud_position, hud_scale, hud_background_color, hud_emoji, language"
-                );
-                std::process::exit(2);
-            };
-
-            let mut config = match load_config_file(&path) {
-                Ok((config, _)) => config,
-                Err(error) => {
-                    eprintln!("{error}");
-                    std::process::exit(1);
-                }
-            };
-
-            let warning = match set_config_value(&mut config, key, value_raw.trim()) {
-                Ok(warning) => warning,
-                Err(error) => {
-                    eprintln!("{error}");
-                    std::process::exit(2);
-                }
-            };
-            if let Err(error) = save_config_file(&path, &config) {
-                eprintln!("{error}");
-                std::process::exit(1);
-            }
-            if let Some(warning) = warning {
-                eprintln!("warning: {warning}");
-            }
-            println!("updated config: {}", path.display());
-            println!("hint: change will be applied automatically (no restart needed)");
-            println!("[effective]");
-            let effective =
-                apply_env_overrides(apply_config_file(default_display_settings(), &config));
-            print_effective_settings(effective);
-            true
+        if let Some(value) = config.display.max_chars_per_line {
+            println!("max_chars_per_line = {}", value);
         }
-        unknown => {
-            eprintln!("Unknown --config command: {unknown}");
-            eprintln!("Usage: cliip-show --config <path|show|init|set>");
-            std::process::exit(2);
+        if let Some(value) = config.display.max_lines {
+            println!("max_lines = {}", value);
         }
+        if let Some(value) = config.display.hud_position {
+            println!("hud_position = {}", value.as_str());
+        }
+        if let Some(value) = config.display.hud_scale {
+            println!("hud_scale = {}", value);
+        }
+        if let Some(value) = config.display.hud_background_color {
+            println!("hud_background_color = {}", value.as_str());
+        }
+        if let Some(value) = &config.display.hud_emoji {
+            println!("hud_emoji = {}", value);
+        }
+        if let Some(value) = config.display.language {
+            println!("language = {}", value.as_str());
+        }
+    } else {
+        println!("config_file = not_found");
     }
+    println!("[effective]");
+    let effective = apply_env_overrides(apply_config_file(default_display_settings(), &config));
+    print_effective_settings(effective);
+    true
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,12 +31,12 @@ pub const MIN_HUD_IMAGE_MAX_HEIGHT: usize = 40;
 pub const MAX_HUD_IMAGE_MAX_HEIGHT: usize = 240;
 
 // Re-exports: 外部モジュールのインポートを一切変更しないようにする
-pub use cli::handle_config_command;
+pub use cli::show_config;
 pub use io::{config_file_path, load_config_file, save_config_file};
 pub use parse::{
-    hud_emoji_validation_error, parse_config_key, parse_f64_setting, parse_f64_value,
-    parse_hud_background_color, parse_hud_emoji, parse_hud_position, parse_language,
-    parse_usize_setting, parse_usize_value, set_config_value,
+    hud_emoji_validation_error, parse_f64_setting, parse_f64_value, parse_hud_background_color,
+    parse_hud_emoji, parse_hud_position, parse_language, parse_usize_setting, parse_usize_value,
+    set_config_value,
 };
 pub use settings::{
     apply_config_file, apply_env_overrides, default_display_settings, display_settings,

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -117,23 +117,6 @@ pub fn parse_usize_setting(raw: &str, default: usize, min: usize, max: usize) ->
     value.clamp(min, max)
 }
 
-pub fn parse_config_key(raw: &str) -> Option<ConfigKey> {
-    match raw {
-        "poll_interval_secs" | "poll-interval-secs" => Some(ConfigKey::PollIntervalSecs),
-        "hud_duration_secs" | "hud-duration-secs" => Some(ConfigKey::HudDurationSecs),
-        "hud_fade_duration_secs" | "hud-fade-duration-secs" => Some(ConfigKey::HudFadeDurationSecs),
-        "max_chars_per_line" | "max-chars-per-line" => Some(ConfigKey::MaxCharsPerLine),
-        "max_lines" | "max-lines" => Some(ConfigKey::MaxLines),
-        "hud_position" | "hud-position" => Some(ConfigKey::HudPosition),
-        "hud_scale" | "hud-scale" => Some(ConfigKey::HudScale),
-        "hud_background_color" | "hud-background-color" => Some(ConfigKey::HudBackgroundColor),
-        "hud_emoji" | "hud-emoji" => Some(ConfigKey::HudEmoji),
-        "hud_image_max_height" | "hud-image-max-height" => Some(ConfigKey::HudImageMaxHeight),
-        "language" => Some(ConfigKey::Language),
-        _ => None,
-    }
-}
-
 /// `set_config_value` 内で f64 フィールドをパース・バリデーション・クランプする共通処理。
 /// 成功時は `(clamped_value, clamp_warning_message)` を返す。
 fn parse_and_clamp_f64(
@@ -368,36 +351,6 @@ mod tests {
         assert_eq!(parse_usize_setting("100", 10, 1, 20), 20);
         assert_eq!(parse_usize_setting("5", 10, 1, 20), 5);
         assert_eq!(parse_usize_setting("abc", 10, 1, 20), 10);
-    }
-
-    #[test]
-    fn parse_config_key_accepts_aliases() {
-        assert_eq!(
-            parse_config_key("poll_interval_secs"),
-            Some(ConfigKey::PollIntervalSecs)
-        );
-        assert_eq!(
-            parse_config_key("poll-interval-secs"),
-            Some(ConfigKey::PollIntervalSecs)
-        );
-        assert_eq!(
-            parse_config_key("hud_position"),
-            Some(ConfigKey::HudPosition)
-        );
-        assert_eq!(parse_config_key("hud-scale"), Some(ConfigKey::HudScale));
-        assert_eq!(parse_config_key("hud_emoji"), Some(ConfigKey::HudEmoji));
-        assert_eq!(parse_config_key("hud-emoji"), Some(ConfigKey::HudEmoji));
-        assert_eq!(
-            parse_config_key("hud_image_max_height"),
-            Some(ConfigKey::HudImageMaxHeight)
-        );
-        assert_eq!(
-            parse_config_key("hud-image-max-height"),
-            Some(ConfigKey::HudImageMaxHeight)
-        );
-        assert_eq!(parse_config_key("hub_background_color"), None);
-        assert_eq!(parse_config_key("hub-background-color"), None);
-        assert_eq!(parse_config_key("unknown"), None);
     }
 
     #[test]

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -1243,7 +1243,7 @@ unsafe fn raw_value_for_control(
 /// 設定ウィンドウのコントロール変更を下書き（`SettingsControls::draft`）に反映するだけで、
 /// ファイル保存も HUD への適用もしない。確定させるには「保存」（`saveSettings:`）を押す。
 ///
-/// クランプ・バリデーションは既存の `set_config_value`（CLI の `--config set` と共通）に委ねる。
+/// クランプ・バリデーションは `set_config_value` に委ねる。
 ///
 /// # Safety
 /// - `APP_STATE` をロックしないこと（呼び出し側が既にロックを保持している）。
@@ -1302,8 +1302,8 @@ pub unsafe fn apply_setting_change(state: &mut AppState, sender: *mut AnyObject)
 }
 
 /// 言語ポップアップの `settingChanged:` から呼ぶ。他の設定と違い下書きを経由せず、選択した
-/// 瞬間に `--config set` と同じ経路（読み込み→検証→保存）でファイルへ書き、`apply_settings_now`
-/// で HUD・設定ウィンドウ・メニューへ即時反映する。
+/// 瞬間に読み込み→検証→保存でファイルへ書き、`apply_settings_now` で HUD・設定ウィンドウ・
+/// メニューへ即時反映する。
 ///
 /// `apply_settings_now` の言語差分側で `draft.language` も一緒に同期する。ここで揃えておかないと
 /// 「保存」ボタンが `draft`（開いた時点のスナップショット）を丸ごと書き戻す際に、今しがた


### PR DESCRIPTION
## 背景

設定を変更する経路が設定ウィンドウと CLI の 2 つあり、設定キーを足すたびに両方のドキュメントへ追随が要る状態だった。変更手段を設定ウィンドウに一本化する。

`--config` のサブコマンド 4 つのうち、読み取り専用の `show` だけを残す。`show` が 1 つだけならサブコマンドの階層を持つ意味がないため、`--config-show` のフラグにした。

| 削除 | 理由 |
|---|---|
| `--config set` | 設定変更を設定ウィンドウに一本化する |
| `--config init` | `save_config_file` が `create_dir_all` するため、設定ウィンドウの保存で設定ファイルが生成される |
| `--config path` | `--config-show` の 1 行目が同じパスを出力する |

環境変数 `CLIIP_SHOW_*` は残す。VRT（`scripts/visual_regression.sh`）が設定の上書きに使っている。

`cliip-show --config set` などをスクリプトで使っている場合は動かなくなる。`--config` は exit 2 で弾かれる。

## 変更内容

- `src/config/cli.rs` — `show_config` だけを残す
- `src/cli.rs` — `--config-show` を追加。`--help` からキー一覧とコマンド例を削り、環境変数一覧に `CLIIP_SHOW_HUD_FADE_DURATION_SECS` を足す
- `src/config/parse.rs` — `parse_config_key` を削除。`--config set` 専用で呼び出し元がなくなる。`pub use` の再エクスポート経由なので clippy の dead code 検出には掛からない
- `scripts/local_check.sh` — 検証用の設定ファイルを TOML の直書きで組み立てる
  - 上書きを環境変数で渡さないのは、環境変数が設定ファイルより優先されるため。設定ウィンドウで保存してもウィンドウを閉じた時点で `display_settings_from_file` 経由で環境変数の値に戻り、ウィンドウの動作確認ができなくなる
- `README.md` / `README.ja.md` — 設定セクションの見出しと本文を差し替える
- `CLAUDE.md` — モジュール構成表の記述を合わせる

## 確認

- `cargo test`（50 件。`parse_config_key` のテスト削除で 51 件から減る）
- `./scripts/visual_regression.sh`（34 ケース）
- `cargo fmt --check` と `cargo clippy --all-targets -- -D warnings`
- `shellcheck scripts/local_check.sh`
- 実機で以下を確認
  - `--config-show` の出力が旧 `--config show` と同じであること
  - `--config` が exit 2 で弾かれること
  - `local_check.sh` が上書きあり・なしの両方で起動し、上書きが `[saved]` と `[effective]` の両方に入ること
- `packaging/` と `.github/` に旧コマンドの記載がないこと

## リリース後の作業

- [ ] [somei-san/homebrew-tap](https://github.com/somei-san/homebrew-tap) の README の設定セクションを差し替える。`--config-show` はリリースするまで存在しないため、先に更新すると未リリースのフラグを案内することになる

````markdown
メニューバーのアイコンから「設定…」を開いて変更します。「お試し表示」で見た目を確認しながら調整できます。変更は再起動なしで反映されます。

現在の設定値は CLI から確認できます。

```bash
cliip-show --config-show
```
````

## 関連リンク

- Issue: #18
- 後続 PR: #24

