### PR TITLE
--config-show の [saved] に hud_image_max_height を出す

### DIFF
--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -1,6 +1,7 @@
 use super::io::{config_file_path, load_config_file};
 use super::settings::{
     apply_config_file, apply_env_overrides, default_display_settings, print_effective_settings,
+    print_saved_settings,
 };
 
 /// `--config-show` の処理。設定の変更手段は設定ウィンドウに一本化しているため、
@@ -30,36 +31,7 @@ pub fn show_config<I: Iterator<Item = String>>(args: &mut I) -> bool {
     if loaded_from_file {
         println!("config_file = exists");
         println!("[saved]");
-        if let Some(value) = config.display.poll_interval_secs {
-            println!("poll_interval_secs = {}", value);
-        }
-        if let Some(value) = config.display.hud_duration_secs {
-            println!("hud_duration_secs = {}", value);
-        }
-        if let Some(value) = config.display.hud_fade_duration_secs {
-            println!("hud_fade_duration_secs = {}", value);
-        }
-        if let Some(value) = config.display.max_chars_per_line {
-            println!("max_chars_per_line = {}", value);
-        }
-        if let Some(value) = config.display.max_lines {
-            println!("max_lines = {}", value);
-        }
-        if let Some(value) = config.display.hud_position {
-            println!("hud_position = {}", value.as_str());
-        }
-        if let Some(value) = config.display.hud_scale {
-            println!("hud_scale = {}", value);
-        }
-        if let Some(value) = config.display.hud_background_color {
-            println!("hud_background_color = {}", value.as_str());
-        }
-        if let Some(value) = &config.display.hud_emoji {
-            println!("hud_emoji = {}", value);
-        }
-        if let Some(value) = config.display.language {
-            println!("language = {}", value.as_str());
-        }
+        print_saved_settings(&config);
     } else {
         println!("config_file = not_found");
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -6,7 +6,7 @@ use super::parse::{
 };
 use super::types::HudBackgroundColor;
 use super::types::{
-    AppConfigFile, DisplayConfigFile, DisplaySettings, HudPosition, LanguageSetting,
+    AppConfigFile, ConfigKey, DisplayConfigFile, DisplaySettings, HudPosition, LanguageSetting,
 };
 use super::{
     DEFAULT_HUD_FADE_DURATION_SECS, DEFAULT_HUD_IMAGE_MAX_HEIGHT, DEFAULT_HUD_SCALE,
@@ -198,6 +198,35 @@ pub fn apply_env_overrides(base: DisplaySettings) -> DisplaySettings {
     settings
 }
 
+/// 設定ファイルに保存済みの値だけを出力する。キーごとの分岐を `ConfigKey` の網羅 match に
+/// 寄せているので、キーを足したときの追随漏れはコンパイルエラーになる。
+pub fn print_saved_settings(config: &AppConfigFile) {
+    for key in ConfigKey::ALL {
+        if let Some(value) = saved_value(config, key) {
+            println!("{} = {}", key.as_str(), value);
+        }
+    }
+}
+
+fn saved_value(config: &AppConfigFile, key: ConfigKey) -> Option<String> {
+    let display = &config.display;
+    match key {
+        ConfigKey::PollIntervalSecs => display.poll_interval_secs.map(|v| v.to_string()),
+        ConfigKey::HudDurationSecs => display.hud_duration_secs.map(|v| v.to_string()),
+        ConfigKey::HudFadeDurationSecs => display.hud_fade_duration_secs.map(|v| v.to_string()),
+        ConfigKey::MaxCharsPerLine => display.max_chars_per_line.map(|v| v.to_string()),
+        ConfigKey::MaxLines => display.max_lines.map(|v| v.to_string()),
+        ConfigKey::HudPosition => display.hud_position.map(|v| v.as_str().to_string()),
+        ConfigKey::HudScale => display.hud_scale.map(|v| v.to_string()),
+        ConfigKey::HudBackgroundColor => {
+            display.hud_background_color.map(|v| v.as_str().to_string())
+        }
+        ConfigKey::HudEmoji => display.hud_emoji.clone(),
+        ConfigKey::HudImageMaxHeight => display.hud_image_max_height.map(|v| v.to_string()),
+        ConfigKey::Language => display.language.map(|v| v.as_str().to_string()),
+    }
+}
+
 pub fn print_effective_settings(settings: DisplaySettings) {
     println!("poll_interval_secs = {}", settings.poll_interval_secs);
     println!("hud_duration_secs = {}", settings.hud_duration_secs);
@@ -241,4 +270,37 @@ fn read_env_option(name: &str) -> Option<String> {
         return None;
     };
     Some(raw.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{default_display_settings, saved_value, settings_to_config_file};
+    use crate::config::ConfigKey;
+
+    /// キーを足したときに `[saved]` の出力から漏れないことを守る。
+    #[test]
+    fn saved_value_covers_every_config_key() {
+        let config = settings_to_config_file(default_display_settings());
+        for key in ConfigKey::ALL {
+            assert!(
+                saved_value(&config, key).is_some(),
+                "{} が [saved] に出ない",
+                key.as_str()
+            );
+        }
+    }
+
+    /// `as_str` が設定ファイルのキー名からずれると、`[saved]` が設定ファイルに無い名前を出す。
+    #[test]
+    fn config_key_names_match_the_config_file() {
+        let config = settings_to_config_file(default_display_settings());
+        let serialized = toml::to_string_pretty(&config).expect("serialize config");
+        for key in ConfigKey::ALL {
+            assert!(
+                serialized.contains(&format!("{} = ", key.as_str())),
+                "{} が設定ファイルのキー名と一致しない",
+                key.as_str()
+            );
+        }
+    }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -113,3 +113,36 @@ pub enum ConfigKey {
     HudImageMaxHeight,
     Language,
 }
+
+impl ConfigKey {
+    /// 設定ファイルに並ぶ順。キーを網羅して回りたい箇所はここを使う。
+    pub const ALL: [ConfigKey; 11] = [
+        ConfigKey::PollIntervalSecs,
+        ConfigKey::HudDurationSecs,
+        ConfigKey::HudFadeDurationSecs,
+        ConfigKey::MaxCharsPerLine,
+        ConfigKey::MaxLines,
+        ConfigKey::HudPosition,
+        ConfigKey::HudScale,
+        ConfigKey::HudBackgroundColor,
+        ConfigKey::HudEmoji,
+        ConfigKey::HudImageMaxHeight,
+        ConfigKey::Language,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ConfigKey::PollIntervalSecs => "poll_interval_secs",
+            ConfigKey::HudDurationSecs => "hud_duration_secs",
+            ConfigKey::HudFadeDurationSecs => "hud_fade_duration_secs",
+            ConfigKey::MaxCharsPerLine => "max_chars_per_line",
+            ConfigKey::MaxLines => "max_lines",
+            ConfigKey::HudPosition => "hud_position",
+            ConfigKey::HudScale => "hud_scale",
+            ConfigKey::HudBackgroundColor => "hud_background_color",
+            ConfigKey::HudEmoji => "hud_emoji",
+            ConfigKey::HudImageMaxHeight => "hud_image_max_height",
+            ConfigKey::Language => "language",
+        }
+    }
+}

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -1619,23 +1619,9 @@ mod tests {
     use super::{config_key_to_tag, tag_to_config_key};
     use crate::config::ConfigKey;
 
-    const ALL_KEYS: [ConfigKey; 11] = [
-        ConfigKey::PollIntervalSecs,
-        ConfigKey::HudDurationSecs,
-        ConfigKey::HudFadeDurationSecs,
-        ConfigKey::MaxCharsPerLine,
-        ConfigKey::MaxLines,
-        ConfigKey::HudPosition,
-        ConfigKey::HudScale,
-        ConfigKey::HudBackgroundColor,
-        ConfigKey::HudEmoji,
-        ConfigKey::HudImageMaxHeight,
-        ConfigKey::Language,
-    ];
-
     #[test]
     fn tag_round_trips_for_all_config_keys() {
-        for key in ALL_KEYS {
+        for key in ConfigKey::ALL {
             let tag = config_key_to_tag(key);
             assert_eq!(tag_to_config_key(tag), Some(key));
         }


### PR DESCRIPTION
## 背景

`--config-show` の `[saved]` がキーごとに `if let Some(...)` を並べる作りになっていて、`hud_image_max_height` が抜けていた。設定ファイルに保存されていても CLI から確認できない。

同じ漏れが再発しないよう、出力を `ConfigKey` から回す形にする。値の取り出しは網羅 match にしたので、キーを足したときの追随漏れはコンパイルエラーになる。

## 変更内容

- `src/config/types.rs` — `ConfigKey::ALL` と `ConfigKey::as_str` を追加
- `src/config/settings.rs` — `[saved]` の出力を `print_saved_settings` に集約し、`ConfigKey::ALL` で回す
- `src/config/cli.rs` — 手で並べていた出力を `print_saved_settings` の呼び出しに置き換える
- `src/settings_window.rs` — テストが持っていた同内容の `ALL_KEYS` を `ConfigKey::ALL` に寄せる

## 確認

- `cargo test`（52 件。全キーが `[saved]` に出ること、`as_str` が設定ファイルのキー名と一致することのテストを追加）
- `./scripts/visual_regression.sh`（34 ケース）
- `cargo fmt --check` と `cargo clippy --all-targets -- -D warnings`
- 実機で `--config-show` を実行し、`[saved]` に `hud_image_max_height` が並ぶこと、キーの順序が `[effective]` と揃うことを確認

## 関連リンク

- Issue: #16
- 関連 PR: #23
