### PR TITLE
支援ページへの導線をメニューと README に足す

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: somei

--- a/README.ja.md
+++ b/README.ja.md
@@ -106,6 +106,12 @@ cargo run
 - [開発ガイド](docs/development.md)
 - [Homebrew Tap リポジトリ](https://github.com/somei-san/homebrew-tap)
 
+## 支援
+
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/somei)
+
+同じリンクはメニューバーの「ビールを奢る…」からも開けます。
+
 ## 解説
 
 アプリ名は[Creepy Nutsのアルバム](https://ja.wikipedia.org/wiki/%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%97%E3%83%BB%E3%82%B7%E3%83%A7%E3%83%BC)のもじりです

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Config file:
 - [Development guide](docs/development.md)
 - [Homebrew tap repository](https://github.com/somei-san/homebrew-tap)
 
+## Support
+
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/somei)
+
+The same link is in the menu bar under "Buy me a beer…".
+
 ## About the name
 
 The name plays on [an album by Creepy Nuts](https://en.wikipedia.org/wiki/Creepy_Nuts).

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,6 +25,9 @@ use crate::text::truncate_text;
 
 pub const FADE_TICK_INTERVAL_SECS: f64 = 1.0 / 60.0;
 
+/// メニューの「ビールを奢る…」から開く支援ページ。
+const SUPPORT_URL: &str = "https://buymeacoffee.com/somei";
+
 pub struct AppState {
     pub last_change_count: isize,
     pub pasteboard: *mut AnyObject,
@@ -77,6 +80,10 @@ pub fn get_delegate_class() -> &'static AnyClass {
         builder.add_method(sel!(togglePause:), toggle_pause as extern "C" fn(_, _, _));
         builder.add_method(sel!(quitApp:), quit_app as extern "C" fn(_, _, _));
         builder.add_method(sel!(openSettings:), open_settings as extern "C" fn(_, _, _));
+        builder.add_method(
+            sel!(openSupportPage:),
+            open_support_page as extern "C" fn(_, _, _),
+        );
         builder.add_method(
             sel!(settingChanged:),
             setting_changed as extern "C" fn(_, _, _),
@@ -758,6 +765,24 @@ extern "C" fn quit_app(_: &AnyObject, _: Sel, _: *mut AnyObject) {
     }
 }
 
+/// 支援ページを既定のブラウザで開く。URL は言語で変えない。
+extern "C" fn open_support_page(_: &AnyObject, _: Sel, _: *mut AnyObject) {
+    unsafe {
+        let url_string = nsstring_from_str(SUPPORT_URL);
+        let url: *mut AnyObject = msg_send![class!(NSURL), URLWithString: url_string];
+        let () = msg_send![url_string, release];
+        if url.is_null() {
+            eprintln!("warning: failed to build support URL: {SUPPORT_URL}");
+            return;
+        }
+        let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+        let opened: bool = msg_send![workspace, openURL: url];
+        if !opened {
+            eprintln!("warning: failed to open support URL: {SUPPORT_URL}");
+        }
+    }
+}
+
 extern "C" fn hide_hud(this: &AnyObject, _: Sel, _: *mut AnyObject) {
     unsafe {
         // AppKit メインスレッドからのみ呼ばれるため、Mutex が poison されるケースは実質発生しない
@@ -836,12 +861,42 @@ extern "C" fn fade_tick(_: &AnyObject, _: Sel, timer: *mut AnyObject) {
 mod tests {
     use super::image_from_pasteboard;
     use super::FADE_TICK_INTERVAL_SECS;
+    use super::{get_delegate_class, SUPPORT_URL};
     use crate::config::DEFAULT_HUD_FADE_DURATION_SECS;
     use crate::objc_helpers::nsstring_from_str;
     use objc2::runtime::AnyObject;
-    use objc2::{class, msg_send};
+    use objc2::{class, msg_send, sel};
     use objc2_foundation::NSSize;
     use std::ptr;
+
+    /// メニュー項目が送るセレクタに応答しないと、クリックした瞬間に unrecognized selector で
+    /// 落ちる。セレクタ名は文字列なのでコンパイルでは食い違いを検出できない。
+    #[test]
+    fn delegate_responds_to_menu_selectors() {
+        let class = get_delegate_class();
+        for selector in [
+            sel!(openSettings:),
+            sel!(togglePause:),
+            sel!(openSupportPage:),
+            sel!(quitApp:),
+        ] {
+            assert!(
+                class.responds_to(selector),
+                "delegate does not respond to {selector:?}"
+            );
+        }
+    }
+
+    /// メニューから開く URL が壊れていると `NSURL` が nil を返し、何も起きない。
+    #[test]
+    fn support_url_is_a_valid_url() {
+        unsafe {
+            let url_string = nsstring_from_str(SUPPORT_URL);
+            let url: *mut AnyObject = msg_send![class!(NSURL), URLWithString: url_string];
+            let () = msg_send![url_string, release];
+            assert!(!url.is_null(), "{SUPPORT_URL} is not a valid URL");
+        }
+    }
 
     /// 一般ペーストボード（ユーザーのクリップボード）を汚さないよう、専用の名前付きペーストボードを使う。
     #[test]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -24,6 +24,7 @@ pub enum Lang {
 pub enum Msg {
     MenuSettings,
     MenuPause,
+    MenuSupport,
     MenuQuit,
     MenuEdit,
     MenuCut,
@@ -66,6 +67,7 @@ pub fn text(lang: Lang, msg: Msg) -> &'static str {
     let (ja, en) = match msg {
         Msg::MenuSettings => ("設定…", "Settings…"),
         Msg::MenuPause => ("一時停止", "Pause"),
+        Msg::MenuSupport => ("ビールを奢る…", "Buy me a beer…"),
         Msg::MenuQuit => ("cliip-show を終了", "Quit cliip-show"),
         Msg::MenuEdit => ("編集", "Edit"),
         Msg::MenuCut => ("切り取り", "Cut"),

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -27,6 +27,7 @@ pub struct StatusItemHandles {
     pub status_item: *mut AnyObject,
     pub pause_item: *mut AnyObject,
     pub settings_item: *mut AnyObject,
+    pub support_item: *mut AnyObject,
     pub quit_item: *mut AnyObject,
 }
 
@@ -85,6 +86,16 @@ pub unsafe fn create_status_item(delegate: &AnyObject, lang: Lang) -> StatusItem
     let separator: *mut AnyObject = msg_send![class!(NSMenuItem), separatorItem];
     let () = msg_send![menu, addItem: separator];
 
+    let support_item = make_menu_item(
+        delegate,
+        i18n::text(lang, Msg::MenuSupport),
+        sel!(openSupportPage:),
+    );
+    let () = msg_send![menu, addItem: support_item];
+
+    let separator: *mut AnyObject = msg_send![class!(NSMenuItem), separatorItem];
+    let () = msg_send![menu, addItem: separator];
+
     let quit_item = make_menu_item(delegate, i18n::text(lang, Msg::MenuQuit), sel!(quitApp:));
     let () = msg_send![menu, addItem: quit_item];
 
@@ -94,6 +105,7 @@ pub unsafe fn create_status_item(delegate: &AnyObject, lang: Lang) -> StatusItem
         status_item,
         pause_item,
         settings_item,
+        support_item,
         quit_item,
     }
 }
@@ -274,6 +286,10 @@ pub unsafe fn apply_language(handles: &MenuHandles, lang: Lang) {
         i18n::text(lang, Msg::MenuSettings),
     );
     set_title(handles.status.pause_item, i18n::text(lang, Msg::MenuPause));
+    set_title(
+        handles.status.support_item,
+        i18n::text(lang, Msg::MenuSupport),
+    );
     set_title(handles.status.quit_item, i18n::text(lang, Msg::MenuQuit));
     set_title(handles.edit.edit_menu_item, i18n::text(lang, Msg::MenuEdit));
     set_title(handles.edit.edit_menu, i18n::text(lang, Msg::MenuEdit));


### PR DESCRIPTION
## 背景

開発への支援を受け取る導線が無かった。Buy Me a Coffee へのリンクを、メニューバーのメニューと README の 2 箇所に置く。

## 変更内容

- `src/menu.rs` — メニューに「ビールを奢る…」を足す。区切り線を挟んで「一時停止」と「cliip-show を終了」の間に置く
- `src/app.rs` — `openSupportPage:` を実装し、`NSWorkspace` で支援ページを開く。セレクタ名は文字列なので、`menu.rs` 側との食い違いはコンパイルでは検出できず、クリックした瞬間に unrecognized selector で落ちる
- `src/i18n.rs` — `Msg::MenuSupport` を追加（日本語「ビールを奢る…」/ 英語 "Buy me a beer…"）
- `README.md` / `README.ja.md` — 支援セクションとバッジを足す
- `.github/FUNDING.yml` — リポジトリに Sponsor ボタンを出す

## 確認

- `cargo test`（54 件。デリゲートがメニューのセレクタに応答すること、支援 URL が `NSURL` で解釈できることのテストを追加）
- `./scripts/visual_regression.sh`（34 ケース）
- `cargo fmt --check` と `cargo clippy --all-targets -- -D warnings`
- 実機でメニューから「ビールを奢る…」を選び、既定のブラウザで支援ページが開くことを確認

## 関連リンク

- Issue: #10
- 後続 PR: #31
- 設定ウィンドウのタブ化: #27

