### PR TITLE
cask の uninstall で自動起動の設定を消さない

### DIFF
--- a/packaging/homebrew/cliip-show.rb.template
+++ b/packaging/homebrew/cliip-show.rb.template
@@ -16,8 +16,10 @@ cask "cliip-show" do
     system_command "/usr/bin/xattr", args: ["-cr", "#{appdir}/Cliip Show.app"]
   end
 
-  uninstall quit:      "io.github.somei-san.cliip-show",
-            launchctl: "io.github.somei-san.cliip-show"
+  # launchctl: は指定しない。読み込みの有無に関わらず LaunchAgent の plist を消すうえ、
+  # uninstall は upgrade でも走るため、更新のたびに自動起動が無効になる。
+  # plist の後始末は zap に任せる。
+  uninstall quit: "io.github.somei-san.cliip-show"
 
   caveats <<~EOS
     Launch it once from Spotlight, or:


### PR DESCRIPTION
## 背景

cask の `uninstall launchctl:` は、指定したラベルの plist を `rm -f ~/Library/LaunchAgents/<label>.plist` で削除する（`Library/Homebrew/cask/artifact/abstract_uninstall.rb:239-247`）。サービスが読み込まれているかは問わない。

`uninstall` の指定は upgrade でも走るため、更新のたびに自動起動が無効になっていた。自動起動が有効かどうかの記録は plist の有無だけなので、消えると設定ごと失われる。ユーザーには何も表示されない。

## 変更内容

- cask の `uninstall` から `launchctl:` を外す。`quit:` は残すので、更新前にアプリは終了する
- plist の後始末は `zap trash:` に任せる（既に列挙してある）

## 仕様の注意点

`brew uninstall` に `--zap` を付けないと plist が残る。次回ログインで launchd が実在しない実行ファイルを起動しようとする。設定ウィンドウで自動起動を切ってからアンインストールすれば残らない。

## 確認

- `cargo test`（145 件）
- `cargo fmt --check`
- `./scripts/build_app_bundle.sh`
- 生成した cask を `ruby -c` で構文検査
- upgrade で plist が残ることの確認は、この cask を含むバージョンをリリースしないと踏めない

## 関連リンク

- Closes #47
