### PR TITLE
自動起動の状態を設定ファイルに持つ

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -42,7 +42,7 @@ cliip-show --config-show
 
 ファイルへの変更は再起動なしで反映されます。
 
-設定キー:
+設定キー（`[display]` 節）:
 - `poll_interval_secs`（既定値: `0.3`、`0.05` - `5.0`）
 - `hud_duration_secs`（既定値: `1.0`、`0.1` - `10.0`）
 - `hud_fade_duration_secs`（既定値: `0.3`、`0.0` - `2.0`、`0.0` でフェードなし）
@@ -56,7 +56,10 @@ cliip-show --config-show
 - `hud_image_max_height`（既定値: `160`、`40` - `240`）画像サムネイルの高さ上限（px）。実際の上限は `hud_scale` 倍され、元画像より大きくは表示しません
 - `language`（既定値: `auto`、`auto` / `ja` / `en`）メニューバーと設定ウィンドウの表示言語。`auto` は macOS の優先言語に従います
 
-環境変数は設定ファイルより優先します。キー名を大文字にして `CLIIP_SHOW_` を付けた名前です。
+設定キー（`[startup]` 節）:
+- `start_at_login`（既定値: `false`）設定ウィンドウの「ログイン時に自動起動」と同じ値です。LaunchAgent の plist はこの値から書き出すため、plist を手で消してもこの値が残っていれば次の起動で書き直します
+
+環境変数は設定ファイルより優先します。キー名を大文字にして `CLIIP_SHOW_` を付けた名前です（`start_at_login` は対象外）。
 
 ```bash
 CLIIP_SHOW_HUD_DURATION_SECS=2.5 \

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -6,7 +6,7 @@ use objc2_foundation::NSString;
 
 use crate::config::{
     apply_config_file, apply_env_overrides, default_display_settings, load_config_file,
-    DisplaySettings,
+    start_at_login_from_config, DisplaySettings,
 };
 use crate::error::AppError;
 use crate::hud::{hud_background_rgba, hud_border_white_alpha};
@@ -18,17 +18,27 @@ use super::AppState;
 // デフォルト poll_interval_secs=0.3 × 10 = 約3秒ごと
 const CONFIG_CHECK_EVERY_N_POLLS: u32 = 10;
 
-/// 設定ファイルを読み込み、既定値・環境変数オーバーライドを適用した `DisplaySettings` を返す。
+/// 設定ファイルを1回読み込み、既定値・環境変数オーバーライドを適用した `DisplaySettings` と
+/// `start_at_login`（`[startup]` 節が無い、またはキーが無ければ `None`）の両方を導く。
 /// ファイル監視の再読み込み（`reload_config_if_changed`）とウィンドウを閉じたときの
-/// 再読み込み（`window_will_close`）の両方から使う。
-pub(crate) fn display_settings_from_file(path: &Path) -> Result<DisplaySettings, AppError> {
+/// 再読み込み（`window_will_close`）の両方から使う。読み込みを1回にまとめているのは、
+/// 2回読むと1回目と2回目の間の外部変更を取りこぼしうるため。
+pub(crate) fn resolved_config_from_file(
+    path: &Path,
+) -> Result<(DisplaySettings, Option<bool>), AppError> {
     let (config, _) = load_config_file(path)?;
     let base = default_display_settings();
-    Ok(apply_env_overrides(apply_config_file(base, &config)))
+    let settings = apply_env_overrides(apply_config_file(base, &config));
+    Ok((settings, start_at_login_from_config(&config)))
+}
+
+/// `resolved_config_from_file` のうち `DisplaySettings` だけを使う呼び出し元向け。
+pub(crate) fn display_settings_from_file(path: &Path) -> Result<DisplaySettings, AppError> {
+    resolved_config_from_file(path).map(|(settings, _)| settings)
 }
 
 pub(super) unsafe fn reload_config_if_changed(state: &mut AppState) {
-    let Some(ref path) = state.config_path else {
+    let Some(path) = state.config_path.clone() else {
         return;
     };
     state.config_check_counter += 1;
@@ -36,12 +46,14 @@ pub(super) unsafe fn reload_config_if_changed(state: &mut AppState) {
         return;
     }
     state.config_check_counter = 0;
-    let current_mtime = std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
+    let current_mtime = std::fs::metadata(&path)
+        .ok()
+        .and_then(|m| m.modified().ok());
     if current_mtime == state.config_mtime {
         return;
     }
-    let new_settings = match display_settings_from_file(path) {
-        Ok(settings) => settings,
+    let (new_settings, start_at_login) = match resolved_config_from_file(&path) {
+        Ok(result) => result,
         Err(err) => {
             eprintln!("warning: config reload failed, keeping current settings: {err}");
             return;
@@ -50,7 +62,29 @@ pub(super) unsafe fn reload_config_if_changed(state: &mut AppState) {
     state.config_mtime = current_mtime;
 
     apply_settings_now(state, new_settings);
+    apply_start_at_login_if_changed(state, start_at_login);
     eprintln!("config reloaded");
+}
+
+/// 手で設定ファイルを書き換えたときも LaunchAgent へ反映する。設定ファイルを読み直す経路と
+/// 保存する経路から使う。`desired` が `None`（`[startup]` 節が無い、または `start_at_login`
+/// キーが無い）なら何もしない。
+pub(crate) unsafe fn apply_start_at_login_if_changed(state: &mut AppState, desired: Option<bool>) {
+    let Some(desired) = desired else {
+        return;
+    };
+    if desired == state.start_at_login {
+        return;
+    }
+
+    // 設定ファイルは既に新しい値を持っている（手で書き換えたのはここに来た理由）ため、
+    // plist の操作が失敗しても state はその値に揃える。次回起動の
+    // login_item::sync_plist_with_config が plist を設定に合わせ直す。
+    if let Err(error) = crate::login_item::apply_desired_state(desired) {
+        eprintln!("warning: {error}");
+    }
+    state.start_at_login = desired;
+    crate::settings_window::sync_login_item_toggle(&state.settings_controls, desired);
 }
 
 /// 新しい設定を state に反映する。ファイル監視の再読み込み・設定ウィンドウからの変更の両方から呼ばれる。

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -18,7 +18,10 @@ mod config_reload;
 mod hud_show;
 mod panels;
 
-pub(crate) use config_reload::{apply_settings_now, display_settings_from_file};
+pub(crate) use config_reload::{
+    apply_settings_now, apply_start_at_login_if_changed, display_settings_from_file,
+    resolved_config_from_file,
+};
 pub(crate) use hud_show::{present_hud, show_sample_image_content, show_text_content};
 
 pub struct AppState {
@@ -33,6 +36,9 @@ pub struct AppState {
     pub fade_ticks_elapsed: u32,
     pub fade_total_ticks: u32,
     pub settings: DisplaySettings,
+    /// ログイン時の自動起動の実効値。設定ファイルの `start_at_login` を正とし、
+    /// 未設定なら plist の有無を初期値とする（`login_item::resolved_start_at_login`）。
+    pub start_at_login: bool,
     pub config_path: Option<PathBuf>,
     pub config_mtime: Option<SystemTime>,
     pub config_check_counter: u32,
@@ -160,6 +166,13 @@ extern "C" fn application_did_finish_launching(this: &AnyObject, _: Sel, _: *mut
             .as_ref()
             .and_then(|p| std::fs::metadata(p).ok())
             .and_then(|m| m.modified().ok());
+        // `login_item::sync_plist_with_config`（main）が既に設定ファイルへ書き戻し済みのはずだが、
+        // その書き込みに失敗した場合に備えて plist の有無へのフォールバックも保つ。
+        let start_at_login = config_path
+            .as_ref()
+            .and_then(|path| crate::config::load_config_file(path).ok())
+            .map(|(config, _)| crate::login_item::resolved_start_at_login(&config))
+            .unwrap_or_else(crate::login_item::is_enabled);
 
         let poll_timer = schedule_poll_timer(this, settings.poll_interval_secs);
 
@@ -184,6 +197,7 @@ extern "C" fn application_did_finish_launching(this: &AnyObject, _: Sel, _: *mut
             fade_ticks_elapsed: 0,
             fade_total_ticks: 0,
             settings,
+            start_at_login,
             config_path,
             config_mtime,
             config_check_counter: 0,
@@ -196,7 +210,7 @@ extern "C" fn application_did_finish_launching(this: &AnyObject, _: Sel, _: *mut
 
         // runModal は実行ループを止めるため、他の経路がロック待ちで固まらないよう
         // APP_STATE のロックを手放した後（上の代入文で既に解放済み）に呼ぶ。
-        panels::prompt_login_item_if_needed(lang);
+        panels::prompt_login_item_if_needed(lang, start_at_login);
 
         // 常駐アプリはウィンドウを持たないので、自分で起動したときは立ち上がった
         // ことが分からない。ログイン時の起動は本人が起動を待っていないため出さない。
@@ -288,7 +302,8 @@ extern "C" fn open_settings(this: &AnyObject, _: Sel, _: *mut AnyObject) {
 
             if state.settings_controls.window.is_null() {
                 let lang = i18n::resolve(state.settings.language);
-                state.settings_controls = crate::settings_window::build_settings_window(this, lang);
+                state.settings_controls =
+                    crate::settings_window::build_settings_window(this, lang, state.start_at_login);
             }
 
             // 既に開いているウィンドウは前面に出すだけにする。他のインスタンスの起動でも
@@ -303,8 +318,11 @@ extern "C" fn open_settings(this: &AnyObject, _: Sel, _: *mut AnyObject) {
                     &state.settings,
                 );
             }
-            // ログイン項目は設定ファイルではなく OS 側の状態なので、下書きとは別に毎回同期する。
-            crate::settings_window::sync_login_item_toggle(&state.settings_controls);
+            // ログイン項目は下書きモデルの対象外なので、下書きとは別に毎回同期する。
+            crate::settings_window::sync_login_item_toggle(
+                &state.settings_controls,
+                state.start_at_login,
+            );
             state.settings_controls.window
         };
 
@@ -340,7 +358,8 @@ extern "C" fn setting_changed(_: &AnyObject, _: Sel, sender: *mut AnyObject) {
 }
 
 /// ログイン項目トグルの `toggleLoginItem:`。他の設定と違い下書きを経由せず、
-/// チェックした瞬間に `login_item::enable`/`disable` を実行して OS の状態を変える。
+/// チェックした瞬間に設定ファイルへ保存し、`login_item::enable`/`disable` で OS の
+/// 状態を変える。設定ファイルを正とするため、保存を plist の操作より先に行う。
 extern "C" fn toggle_login_item(_: &AnyObject, _: Sel, sender: *mut AnyObject) {
     unsafe {
         // AppKit メインスレッドからのみ呼ばれるため、Mutex が poison されるケースは実質発生しない
@@ -350,18 +369,48 @@ extern "C" fn toggle_login_item(_: &AnyObject, _: Sel, sender: *mut AnyObject) {
         };
 
         let checked: isize = msg_send![sender, state];
-        let result = if checked != 0 {
+        let desired = checked != 0;
+
+        if !persist_start_at_login(state, desired) {
+            // 失敗したのにチェックだけ付いた状態を避け、実際の状態に表示を戻す。
+            // 警告は persist_start_at_login が出力済み。
+            crate::settings_window::sync_login_item_toggle(
+                &state.settings_controls,
+                state.start_at_login,
+            );
+            return;
+        }
+
+        if let Err(error) = if desired {
             crate::login_item::enable()
         } else {
             crate::login_item::disable()
-        };
-
-        if let Err(error) = result {
+        } {
+            // 設定ファイルは正しい値のまま。次回起動の login_item::sync_plist_with_config が
+            // plist を設定に合わせ直すため、ここでは警告に留める。
             eprintln!("warning: {error}");
-            // 失敗したのにチェックだけ付いた状態を避け、実際の状態に表示を戻す。
-            crate::settings_window::sync_login_item_toggle(&state.settings_controls);
         }
     }
+}
+
+/// 自動起動の値を設定ファイルへ保存し、成功したら `state.start_at_login`／`config_mtime` を
+/// 更新する。設定ファイルを正とするため、`login_item::enable`/`disable` より必ず先に呼ぶこと。
+/// 保存に失敗したら state は変えず `false` を返す（呼び出し側は表示を実際の値へ戻すだけでよい）
+/// （`toggleLoginItem:` と自動起動確認ダイアログの「有効にする」の両方から使う）。
+fn persist_start_at_login(state: &mut AppState, value: bool) -> bool {
+    let Some(path) = state.config_path.clone() else {
+        eprintln!("warning: config path is not resolved; cannot save start_at_login");
+        return false;
+    };
+    if let Err(error) = crate::login_item::save_start_at_login(&path, value) {
+        eprintln!("warning: {error}");
+        return false;
+    }
+    state.start_at_login = value;
+    state.config_mtime = std::fs::metadata(&path)
+        .ok()
+        .and_then(|m| m.modified().ok());
+    true
 }
 
 // NSRectEdge: maxX。ボタン/フィールドの右側に popover を出す（`show_emoji_help_popover`・
@@ -652,14 +701,15 @@ extern "C" fn window_will_close(_: &AnyObject, _: Sel, notification: *mut AnyObj
         let Some(path) = state.config_path.clone() else {
             return;
         };
-        let new_settings = match display_settings_from_file(&path) {
-            Ok(settings) => settings,
+        let (new_settings, start_at_login) = match resolved_config_from_file(&path) {
+            Ok(result) => result,
             Err(err) => {
                 eprintln!("warning: config reload failed, keeping current settings: {err}");
                 return;
             }
         };
         apply_settings_now(state, new_settings);
+        apply_start_at_login_if_changed(state, start_at_login);
         state.config_mtime = std::fs::metadata(&path)
             .ok()
             .and_then(|m| m.modified().ok());

--- a/src/app/panels.rs
+++ b/src/app/panels.rs
@@ -25,12 +25,14 @@ const NS_LINK_ATTRIBUTE_NAME: &str = "NSLink";
 /// 常駐が前提のアプリで自動起動が切れている状態は設定が未完了なので、断られても促し続ける。
 /// 抑止チェックボックスを入れて閉じたときだけ `mark_prompted` を記録し、以後は出さない。
 ///
+/// `start_at_login` は `login_item::resolved_start_at_login` で解決済みの値を渡すこと。
+///
 /// # Safety
 /// - `APP_STATE` のロックを保持したまま呼ばないこと。`runModal` が実行ループを止めるため、
 ///   他の経路がロック待ちで固まる。
 /// - AppKit のメインスレッドから呼ぶこと。
-pub(super) unsafe fn prompt_login_item_if_needed(lang: Lang) {
-    if crate::login_item::is_enabled() || crate::login_item::has_prompted() {
+pub(super) unsafe fn prompt_login_item_if_needed(lang: Lang, start_at_login: bool) {
+    if start_at_login || crate::login_item::has_prompted() {
         return;
     }
 
@@ -80,8 +82,17 @@ pub(super) unsafe fn prompt_login_item_if_needed(lang: Lang) {
     }
 
     if response == NS_ALERT_FIRST_BUTTON_RETURN {
-        if let Err(error) = crate::login_item::enable() {
-            eprintln!("warning: {error}");
+        // 設定ファイルを正とするため、plist の enable より先に保存する。
+        // AppKit メインスレッドからのみ呼ばれるため、Mutex が poison されるケースは実質発生しない
+        let mut guard = APP_STATE.lock().expect("APP_STATE lock poisoned");
+        if let Some(state) = guard.as_mut() {
+            if super::persist_start_at_login(state, true) {
+                if let Err(error) = crate::login_item::enable() {
+                    // 設定ファイルは正しい値のまま。次回起動の
+                    // login_item::sync_plist_with_config が plist を設定に合わせ直す。
+                    eprintln!("warning: {error}");
+                }
+            }
         }
     }
 }

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -37,6 +37,7 @@ pub fn show_config<I: Iterator<Item = String>>(args: &mut I) -> bool {
     }
     println!("[effective]");
     let effective = apply_env_overrides(apply_config_file(default_display_settings(), &config));
-    print_effective_settings(effective);
+    let start_at_login = crate::login_item::resolved_start_at_login(&config);
+    print_effective_settings(effective, start_at_login);
     true
 }

--- a/src/config/io.rs
+++ b/src/config/io.rs
@@ -82,9 +82,12 @@ mod tests {
 
     use super::{config_file_path_with, load_config_file, save_config_file};
     use crate::config::settings::{
-        apply_config_file, default_display_settings, settings_to_config_file,
+        apply_config_file, default_display_settings, merge_display_settings,
+        settings_to_config_file, start_at_login_from_config,
     };
-    use crate::config::types::{HudBackgroundColor, HudPosition, LanguageSetting};
+    use crate::config::types::{
+        AppConfigFile, HudBackgroundColor, HudPosition, LanguageSetting, StartupConfigFile,
+    };
     use crate::error::AppError;
 
     /// テストごとに独立したディレクトリを使う（cargo test は並列実行のため共有すると干渉する）。
@@ -158,6 +161,70 @@ mod tests {
 
         let reloaded = apply_config_file(default_display_settings(), &loaded);
         assert_eq!(reloaded.hud_emoji, "");
+    }
+
+    /// `[startup]` セクションも他のセクションと同じく保存 → 再読込で値が変わらないこと。
+    /// `settings_to_config_file` は保存経路の中間表現で `start_at_login` を常に `Some(false)`
+    /// に固定するため通さず、`AppConfigFile` を直接組んで `Some(true)` が保たれるかを見る。
+    #[test]
+    fn start_at_login_survives_a_save_load_cycle() {
+        let temp = TempConfigDir::new("startup");
+        let config = AppConfigFile {
+            startup: StartupConfigFile {
+                start_at_login: Some(true),
+            },
+            ..Default::default()
+        };
+
+        let config_path = temp.path("config.toml");
+        save_config_file(&config_path, &config).expect("save config");
+        let (loaded, existed) = load_config_file(&config_path).expect("load config");
+        assert!(existed);
+        assert_eq!(start_at_login_from_config(&loaded), Some(true));
+    }
+
+    /// `[startup]` セクション自体が無い設定ファイルは、`false` ではなく「未設定」
+    /// （`None`）として読めること。plist の有無からの移行はこの区別に依存する。
+    #[test]
+    fn absent_startup_section_is_none() {
+        let temp = TempConfigDir::new("no-startup-section");
+        let config_path = temp.path("config.toml");
+        fs::write(&config_path, "[display]\npoll_interval_secs = 0.5\n")
+            .expect("write config without [startup]");
+
+        let (loaded, existed) = load_config_file(&config_path).expect("load config");
+        assert!(existed);
+        assert_eq!(start_at_login_from_config(&loaded), None);
+    }
+
+    /// `save_settings`（設定ウィンドウの「保存」ボタン）が使う `merge_display_settings` を
+    /// 経由して保存しても、既存の `start_at_login` を巻き戻さないこと。丸ごと上書きに
+    /// 戻す変更が起きたらここで落ちる。
+    #[test]
+    fn merge_display_settings_preserves_existing_start_at_login() {
+        let temp = TempConfigDir::new("preserve-startup");
+        let config_path = temp.path("config.toml");
+
+        let existing = AppConfigFile {
+            startup: StartupConfigFile {
+                start_at_login: Some(true),
+            },
+            ..Default::default()
+        };
+        save_config_file(&config_path, &existing).expect("save initial config");
+
+        let mut draft_settings = default_display_settings();
+        draft_settings.hud_scale = 1.7;
+        let (config, _) = load_config_file(&config_path).expect("load config");
+        let merged = merge_display_settings(config, draft_settings);
+        save_config_file(&config_path, &merged).expect("save merged config");
+
+        let (loaded, _) = load_config_file(&config_path).expect("reload config");
+        assert_eq!(start_at_login_from_config(&loaded), Some(true));
+        assert_eq!(
+            apply_config_file(default_display_settings(), &loaded).hud_scale,
+            1.7
+        );
     }
 
     /// 初回起動（設定ファイルなし）はエラーではなくデフォルト設定で立ち上がる。

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -43,9 +43,10 @@ pub use parse::{
 };
 pub use settings::{
     apply_config_file, apply_env_overrides, default_display_settings, display_settings,
-    print_effective_settings, settings_to_config_file,
+    merge_display_settings, print_effective_settings, settings_to_config_file,
+    start_at_login_from_config,
 };
 pub use types::{
     AppConfigFile, ConfigKey, DisplayConfigFile, DisplaySettings, HudBackgroundColor, HudPosition,
-    LanguageSetting,
+    LanguageSetting, StartupConfigFile,
 };

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -335,6 +335,20 @@ pub fn set_config_value(
                 )));
             }
         }
+        ConfigKey::StartAtLogin => {
+            let raw = value.trim();
+            let parsed = match raw {
+                "true" => true,
+                "false" => false,
+                _ => {
+                    return Err(AppError::InvalidValue {
+                        key: "start_at_login",
+                        message: format!("{raw} (allowed: true, false)"),
+                    })
+                }
+            };
+            config.startup.start_at_login = Some(parsed);
+        }
     }
     Ok(None)
 }
@@ -551,6 +565,22 @@ mod tests {
     }
 
     #[test]
+    fn set_config_value_accepts_start_at_login() {
+        let mut config = AppConfigFile::default();
+        let warning =
+            set_config_value(&mut config, ConfigKey::StartAtLogin, "true").expect("set value");
+        assert_eq!(config.startup.start_at_login, Some(true));
+        assert!(warning.is_none());
+
+        set_config_value(&mut config, ConfigKey::StartAtLogin, "false").expect("set value");
+        assert_eq!(config.startup.start_at_login, Some(false));
+
+        let err = set_config_value(&mut config, ConfigKey::StartAtLogin, "maybe")
+            .expect_err("reject invalid value");
+        assert!(err.to_string().contains("start_at_login"));
+    }
+
+    #[test]
     fn apply_config_file_treats_empty_hud_emoji_as_no_icon() {
         let base = default_display_settings();
         assert_ne!(base.hud_emoji, "");
@@ -559,6 +589,7 @@ mod tests {
                 hud_emoji: Some(String::new()),
                 ..Default::default()
             },
+            ..Default::default()
         };
         let settings = apply_config_file(base, &config);
         assert_eq!(settings.hud_emoji, "");
@@ -575,6 +606,7 @@ mod tests {
                 max_chars_per_line: Some(1000),  // above MAX_TRUNCATE_MAX_WIDTH
                 ..Default::default()
             },
+            ..Default::default()
         };
         let settings = apply_config_file(base, &config);
         assert_eq!(settings.poll_interval_secs, MIN_POLL_INTERVAL_SECS);
@@ -592,6 +624,7 @@ mod tests {
                 hud_duration_secs: Some(f64::INFINITY),
                 ..Default::default()
             },
+            ..Default::default()
         };
         let settings = apply_config_file(base, &config);
         assert_eq!(settings.poll_interval_secs, POLL_INTERVAL_SECS);

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -7,6 +7,7 @@ use super::parse::{
 use super::types::HudBackgroundColor;
 use super::types::{
     AppConfigFile, ConfigKey, DisplayConfigFile, DisplaySettings, HudPosition, LanguageSetting,
+    StartupConfigFile,
 };
 use super::{
     DEFAULT_HUD_BACKGROUND_OPACITY, DEFAULT_HUD_FADE_DURATION_SECS, DEFAULT_HUD_IMAGE_MAX_HEIGHT,
@@ -255,10 +256,11 @@ fn saved_value(config: &AppConfigFile, key: ConfigKey) -> Option<String> {
         ConfigKey::HudEmoji => display.hud_emoji.clone(),
         ConfigKey::HudImageMaxHeight => display.hud_image_max_height.map(|v| v.to_string()),
         ConfigKey::Language => display.language.map(|v| v.as_str().to_string()),
+        ConfigKey::StartAtLogin => config.startup.start_at_login.map(|v| v.to_string()),
     }
 }
 
-pub fn print_effective_settings(settings: DisplaySettings) {
+pub fn print_effective_settings(settings: DisplaySettings, start_at_login: bool) {
     println!("poll_interval_secs = {}", settings.poll_interval_secs);
     println!("hud_duration_secs = {}", settings.hud_duration_secs);
     println!(
@@ -280,6 +282,14 @@ pub fn print_effective_settings(settings: DisplaySettings) {
     println!("hud_emoji = {}", settings.hud_emoji);
     println!("hud_image_max_height = {}", settings.hud_image_max_height);
     println!("language = {}", settings.language.as_str());
+    println!("start_at_login = {start_at_login}");
+}
+
+/// 設定ファイルに保存済みの自動起動の値。未設定（`[startup]` 節が無い、または
+/// `start_at_login` キーが無い）と、明示的に `false` が保存されている状態を
+/// 呼び出し側が区別できるよう `Option` のまま返す。
+pub fn start_at_login_from_config(config: &AppConfigFile) -> Option<bool> {
+    config.startup.start_at_login
 }
 
 pub fn settings_to_config_file(settings: DisplaySettings) -> AppConfigFile {
@@ -298,7 +308,24 @@ pub fn settings_to_config_file(settings: DisplaySettings) -> AppConfigFile {
             hud_image_max_height: Some(settings.hud_image_max_height),
             language: Some(settings.language),
         },
+        // `DisplaySettings` は自動起動の値を持たないため、ここは常に未設定
+        // （`StartupConfigFile::default()`）。`Some(false)` を返すと、この関数の
+        // 戻り値がそのまま保存された場合に自動起動が黙って無効化されてしまう。
+        // 未設定なら plist の有無から復元できるため被害が出ない。
+        startup: StartupConfigFile::default(),
     }
+}
+
+/// 読み込み済みの設定ファイルへ `settings` の `display` セクションだけを差し替える
+/// （load-merge-save の merge 部分）。`display` 以外のセクション（`startup` 等、下書きの
+/// 対象外のキー）は `config` の値をそのまま残す。設定ウィンドウの「保存」ボタン
+/// （`save_settings`）から使う。
+pub fn merge_display_settings(
+    mut config: AppConfigFile,
+    settings: DisplaySettings,
+) -> AppConfigFile {
+    config.display = settings_to_config_file(settings).display;
+    config
 }
 
 #[cfg(test)]
@@ -323,10 +350,13 @@ mod tests {
         }
     }
 
-    /// キーを足したときに `[saved]` の出力から漏れないことを守る。
+    /// キーを足したときに `[saved]` の出力から漏れないことを守る。`settings_to_config_file`
+    /// は `start_at_login` を常に未設定で返すため、`ConfigKey::StartAtLogin` 分だけ
+    /// 値を持たせて確認する。
     #[test]
     fn saved_value_covers_every_config_key() {
-        let config = settings_to_config_file(default_display_settings());
+        let mut config = settings_to_config_file(default_display_settings());
+        config.startup.start_at_login = Some(true);
         for key in ConfigKey::ALL {
             assert!(
                 saved_value(&config, key).is_some(),
@@ -447,9 +477,11 @@ mod tests {
         assert_eq!(settings.hud_position, HudPosition::Bottom);
     }
 
-    /// 全キーが `CLIIP_SHOW_<キー名大文字>` の環境変数で上書きできること。
-    /// production 側の変数名リテラルの書き換え・追随漏れをここで落とす
+    /// `DisplaySettings` に属する全キーが `CLIIP_SHOW_<キー名大文字>` の環境変数で
+    /// 上書きできること。production 側の変数名リテラルの書き換え・追随漏れをここで落とす
     /// （命名規約は docs/development.md の環境変数の節）。
+    /// `start_at_login` は `DisplaySettings` を持たず環境変数の上書き対象外のため、
+    /// このテストでは飛ばす。
     #[test]
     fn every_config_key_is_reachable_via_env() {
         for key in ConfigKey::ALL {
@@ -467,6 +499,7 @@ mod tests {
                 ConfigKey::HudEmoji => "🍺",
                 ConfigKey::HudImageMaxHeight => "80",
                 ConfigKey::Language => "ja",
+                ConfigKey::StartAtLogin => continue,
             };
             let env_name = format!("CLIIP_SHOW_{}", key.as_str().to_uppercase());
             let settings = apply_env_overrides_with(default_display_settings(), |name| {
@@ -492,9 +525,11 @@ mod tests {
     }
 
     /// `as_str` が設定ファイルのキー名からずれると、`[saved]` が設定ファイルに無い名前を出す。
+    /// `start_at_login` は未設定だと TOML に出力されないため、`Some(true)` を持たせて確認する。
     #[test]
     fn config_key_names_match_the_config_file() {
-        let config = settings_to_config_file(default_display_settings());
+        let mut config = settings_to_config_file(default_display_settings());
+        config.startup.start_at_login = Some(true);
         let serialized = toml::to_string_pretty(&config).expect("serialize config");
         for key in ConfigKey::ALL {
             assert!(

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -83,6 +83,8 @@ pub struct DisplaySettings {
 pub struct AppConfigFile {
     #[serde(default)]
     pub display: DisplayConfigFile,
+    #[serde(default)]
+    pub startup: StartupConfigFile,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -101,6 +103,11 @@ pub struct DisplayConfigFile {
     pub language: Option<LanguageSetting>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct StartupConfigFile {
+    pub start_at_login: Option<bool>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigKey {
     PollIntervalSecs,
@@ -115,11 +122,12 @@ pub enum ConfigKey {
     HudEmoji,
     HudImageMaxHeight,
     Language,
+    StartAtLogin,
 }
 
 impl ConfigKey {
     /// 設定ファイルに並ぶ順。キーを網羅して回りたい箇所はここを使う。
-    pub const ALL: [ConfigKey; 12] = [
+    pub const ALL: [ConfigKey; 13] = [
         ConfigKey::PollIntervalSecs,
         ConfigKey::HudDurationSecs,
         ConfigKey::HudFadeDurationSecs,
@@ -132,6 +140,7 @@ impl ConfigKey {
         ConfigKey::HudEmoji,
         ConfigKey::HudImageMaxHeight,
         ConfigKey::Language,
+        ConfigKey::StartAtLogin,
     ];
 
     pub fn as_str(self) -> &'static str {
@@ -148,6 +157,7 @@ impl ConfigKey {
             ConfigKey::HudEmoji => "hud_emoji",
             ConfigKey::HudImageMaxHeight => "hud_image_max_height",
             ConfigKey::Language => "language",
+            ConfigKey::StartAtLogin => "start_at_login",
         }
     }
 }

--- a/src/login_item.rs
+++ b/src/login_item.rs
@@ -46,6 +46,13 @@ pub fn is_enabled() -> bool {
     plist_path().is_some_and(|path| path.exists())
 }
 
+/// 設定ファイルの値を正としつつ、未設定なら plist の有無を実効値として使う
+/// （`start_at_login_from_config` が区別する「未設定」を、呼び出し側が使える1つの
+/// bool へ解決する）。
+pub fn resolved_start_at_login(config: &crate::config::AppConfigFile) -> bool {
+    crate::config::start_at_login_from_config(config).unwrap_or_else(is_enabled)
+}
+
 fn current_uid() -> Result<u32, AppError> {
     let home = home_dir().ok_or_else(|| {
         AppError::ConfigResolve("failed to resolve HOME for uid lookup".to_string())
@@ -140,6 +147,104 @@ pub fn repair_stale_plist() -> Result<(), AppError> {
     Ok(())
 }
 
+/// 設定ファイルの `start_at_login` を正として、LaunchAgent の plist をその値に合わせる。
+/// `[startup]` 節を持たない設定ファイルで plist が実在するときだけ、`true` を書き戻す
+/// （plist が外から消えても、次の起動でここが設定から復元できるようにするため）。
+/// plist が無ければ書き戻さない。設定ファイルを持たない環境で自動起動を使っていない
+/// 利用者に、書き戻しのためだけの設定ファイルを作らせないため。
+///
+/// 設定ファイルの読み書きに失敗したらエラーを返す。呼び出し側（`main`）は警告に
+/// 留めて起動を続ける。
+pub fn sync_plist_with_config() -> Result<(), AppError> {
+    let config_path = crate::config::config_file_path()?;
+    let (mut config, _) = crate::config::load_config_file(&config_path)?;
+
+    let plist_exists = is_enabled();
+    let desired = match crate::config::start_at_login_from_config(&config) {
+        Some(value) => value,
+        None => {
+            if let Some(value) = start_at_login_to_persist(plist_exists) {
+                config.startup.start_at_login = Some(value);
+                crate::config::save_config_file(&config_path, &config)?;
+            }
+            plist_exists
+        }
+    };
+
+    apply_desired_state(desired)
+}
+
+/// 設定の希望値へ plist を合わせる。`login_item_action` で行動（`Enable`/`Repair`/`Disable`/
+/// 何もしない）を決めて実行する。`sync_plist_with_config` と、設定ファイルの手編集を拾う
+/// ファイル監視の再読み込みの両方から使う。
+pub fn apply_desired_state(desired_enabled: bool) -> Result<(), AppError> {
+    let plist_exists = is_enabled();
+    let action = login_item_action(
+        desired_enabled,
+        plist_exists,
+        current_exe_is_installed_app_bundle(),
+    );
+    if desired_enabled && action == LoginItemAction::None {
+        // 開発ビルドのパスを plist に焼き付けると、次のビルドで自動起動が黙って止まる。
+        // 書き出しを見送ったことは利用者から見えないので、ここで知らせる。
+        eprintln!(
+            "warning: start_at_login is enabled but the running executable is not an installed .app; skipping plist creation"
+        );
+    }
+    match action {
+        LoginItemAction::Enable => enable(),
+        LoginItemAction::Repair => repair_stale_plist(),
+        LoginItemAction::Disable => disable(),
+        LoginItemAction::None => Ok(()),
+    }
+}
+
+/// 現在の実行ファイルが、インストール済みの `.app` の中にあるか。
+/// `current_exe()` に失敗したときは安全側に倒し `false` とする。
+fn current_exe_is_installed_app_bundle() -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        return false;
+    };
+    // `current_exe()` はシンボリックリンクを解決しない。cask が張ったリンク経由で
+    // 起動すると `.app` の中かどうかを判定できないため、実体のパスに直す。
+    let exe = fs::canonicalize(&exe).unwrap_or(exe);
+    is_installed_app_bundle(&exe)
+}
+
+/// 設定に値が無いときの書き戻し判断（副作用なし）。plist があるときだけ `true` を書き戻す。
+/// plist が無いときに書き戻さないのは、自動起動を使っていない利用者に、書き戻しのためだけの
+/// 設定ファイルを作らせないため。
+fn start_at_login_to_persist(plist_exists: bool) -> Option<bool> {
+    plist_exists.then_some(true)
+}
+
+/// 設定の希望値と plist の実在から、次に取る行動を決める（副作用なし）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoginItemAction {
+    Enable,
+    Repair,
+    Disable,
+    None,
+}
+
+/// `installed_app_bundle` は `is_installed_app_bundle` の結果（実行ファイルがインストール済み
+/// `.app` の中にあるか）。plist が無い状態で新規に書き出す（`Enable`）のは、インストール済み
+/// `.app` から実行しているときだけに限る。開発ビルドや `cargo run` の実行ファイルパスを
+/// 焼き付けると、次のビルドで自動起動が黙って壊れるため。
+fn login_item_action(
+    desired_enabled: bool,
+    plist_exists: bool,
+    installed_app_bundle: bool,
+) -> LoginItemAction {
+    match (desired_enabled, plist_exists) {
+        (true, false) if installed_app_bundle => LoginItemAction::Enable,
+        (true, false) => LoginItemAction::None,
+        (true, true) => LoginItemAction::Repair,
+        (false, true) => LoginItemAction::Disable,
+        (false, false) => LoginItemAction::None,
+    }
+}
+
 /// `launchctl bootout` で読み込みを解除し、plist を削除する。
 ///
 /// `bootout` の失敗は警告に留めて plist の削除まで進める。エージェントが読み込まれていない
@@ -166,6 +271,14 @@ pub fn disable() -> Result<(), AppError> {
             source,
         }),
     }
+}
+
+/// 自動起動の値だけを設定ファイルへ書く。書き込む前に現在のファイルを読み直すのは、
+/// 外部エディタで変更された他のキーを巻き戻さないため。
+pub fn save_start_at_login(path: &Path, value: bool) -> Result<(), AppError> {
+    let (mut config, _) = crate::config::load_config_file(path)?;
+    config.startup.start_at_login = Some(value);
+    crate::config::save_config_file(path, &config)
 }
 
 /// 自動起動確認ダイアログを抑止したかどうかのマーカーファイルのパス。
@@ -357,6 +470,7 @@ pub fn plist_xml(executable: &Path, log_path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::{launched_with_login_flag, LOGIN_FLAG, LOGIN_ITEM_LABEL};
+    use super::{login_item_action, start_at_login_to_persist, LoginItemAction};
     use super::{needs_repair, plist_xml, program_arguments_in_plist, stable_executable_path};
     use std::path::Path;
 
@@ -551,5 +665,61 @@ mod tests {
         );
         assert!(xml.contains("A &amp; B"));
         assert!(!xml.contains("A & B"));
+    }
+
+    #[test]
+    fn login_item_action_enables_when_desired_missing_and_installed() {
+        assert_eq!(
+            login_item_action(true, false, true),
+            LoginItemAction::Enable
+        );
+    }
+
+    // インストール済み .app の外（`cargo run`・開発ビルド・Homebrew formula 時代のパス等）
+    // から実行しているときに新規作成すると、次のビルド・アンインストールでパスが消えて
+    // 自動起動が黙って壊れる。plist を書かず何もしない。
+    #[test]
+    fn login_item_action_does_nothing_when_desired_missing_and_not_installed() {
+        assert_eq!(login_item_action(true, false, false), LoginItemAction::None);
+    }
+
+    #[test]
+    fn login_item_action_repairs_when_desired_and_present() {
+        assert_eq!(
+            login_item_action(true, true, false),
+            LoginItemAction::Repair
+        );
+        assert_eq!(login_item_action(true, true, true), LoginItemAction::Repair);
+    }
+
+    #[test]
+    fn login_item_action_disables_when_not_desired_but_present() {
+        assert_eq!(
+            login_item_action(false, true, false),
+            LoginItemAction::Disable
+        );
+        assert_eq!(
+            login_item_action(false, true, true),
+            LoginItemAction::Disable
+        );
+    }
+
+    #[test]
+    fn login_item_action_does_nothing_when_not_desired_and_absent() {
+        assert_eq!(
+            login_item_action(false, false, false),
+            LoginItemAction::None
+        );
+        assert_eq!(login_item_action(false, false, true), LoginItemAction::None);
+    }
+
+    #[test]
+    fn start_at_login_to_persist_writes_back_true_when_plist_exists() {
+        assert_eq!(start_at_login_to_persist(true), Some(true));
+    }
+
+    #[test]
+    fn start_at_login_to_persist_writes_nothing_when_plist_is_absent() {
+        assert_eq!(start_at_login_to_persist(false), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
             return;
         }
 
-        if let Err(error) = cliip_show::login_item::repair_stale_plist() {
+        if let Err(error) = cliip_show::login_item::sync_plist_with_config() {
             eprintln!("warning: {error}");
         }
 

--- a/src/png.rs
+++ b/src/png.rs
@@ -116,7 +116,8 @@ pub enum SettingsPane {
 /// - 実ウィンドウの背景（ここでは決定性のために不透明背景を合成しており、
 ///   実アプリの背景まわりの退行はこのスナップショットでは検出できない）
 ///
-/// 自動起動トグルは実行マシンの LaunchAgent の有無で初期値が変わるため、OFF に固定する。
+/// 自動起動トグルは環境依存の値（LaunchAgent の有無・設定ファイルの内容）に触れず、
+/// ベースラインが環境非依存になるよう OFF 固定で渡す。
 pub fn render_settings_png(pane: SettingsPane, output_path: &str) -> Result<(), AppError> {
     unsafe {
         let _app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
@@ -125,7 +126,7 @@ pub fn render_settings_png(pane: SettingsPane, output_path: &str) -> Result<(), 
 
         // アクションは一切発火させないので、AppState 未初期化の素の delegate でよい
         let delegate: *mut AnyObject = msg_send![crate::app::get_delegate_class(), new];
-        let mut controls = crate::settings_window::build_settings_window(&*delegate, lang);
+        let mut controls = crate::settings_window::build_settings_window(&*delegate, lang, false);
         if controls.window.is_null() {
             let () = msg_send![delegate, release];
             return Err(AppError::RenderFailed(
@@ -134,9 +135,6 @@ pub fn render_settings_png(pane: SettingsPane, output_path: &str) -> Result<(), 
         }
         // プレースホルダ（既定値）のままではなく、環境変数まで効かせた実効設定を写す
         crate::settings_window::sync_controls_from_settings(&mut controls, &settings);
-        // 自動起動トグルは CLIIP_SHOW_* で上書きできず、実行マシンの LaunchAgent の有無が
-        // 写り込む。ベースラインを環境非依存にするため OFF に固定する
-        let () = msg_send![controls.login_item_toggle, setState: 0isize];
 
         let tab_index: isize = match pane {
             SettingsPane::Settings => crate::settings_window::TAB_INDEX_SETTINGS,

--- a/src/settings_window/build.rs
+++ b/src/settings_window/build.rs
@@ -227,7 +227,11 @@ unsafe fn add_pane_tab(
 ///
 /// # Safety
 /// AppKit のメインスレッドから呼ぶこと。
-pub unsafe fn build_settings_window(delegate: &AnyObject, lang: Lang) -> SettingsControls {
+pub unsafe fn build_settings_window(
+    delegate: &AnyObject,
+    lang: Lang,
+    start_at_login: bool,
+) -> SettingsControls {
     let placeholder = default_display_settings();
     let mut localized: Vec<LocalizedControl> = Vec::new();
 
@@ -415,7 +419,7 @@ pub unsafe fn build_settings_window(delegate: &AnyObject, lang: Lang) -> Setting
         delegate,
         row.next(),
         lang,
-        crate::login_item::is_enabled(),
+        start_at_login,
         &mut localized,
     );
     // 行数が定数からずれると document_height と row_bottom_y の前提が崩れ、行がはみ出す

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -94,8 +94,9 @@ pub struct SettingsControls {
     /// 表示言語のポップアップ。他の設定行と違い下書き→保存のモデルには乗らず、選択した瞬間に
     /// 設定ファイルへ保存する（`apply_language_setting_change`）。
     pub language_popup: *mut AnyObject,
-    /// ログイン時の自動起動トグル。下書き→保存のモデルには乗らず、
-    /// チェックした瞬間に `login_item::enable`/`disable` を呼ぶ（`toggleLoginItem:`）。
+    /// ログイン時の自動起動トグル。下書き→保存のモデルには乗らず、チェックした瞬間に
+    /// 設定ファイルへ保存し、`login_item::enable`/`disable` で plist をそれに合わせる
+    /// （`toggleLoginItem:`）。
     pub login_item_toggle: *mut AnyObject,
     /// ウィンドウ内で編集中の下書き。「保存」（`saveSettings:`）を押すまで設定ファイルには
     /// 反映しない。`settingChanged:` はこの下書きだけを更新する。
@@ -163,6 +164,7 @@ pub fn config_key_to_tag(key: ConfigKey) -> isize {
         ConfigKey::HudImageMaxHeight => 9,
         ConfigKey::Language => 10,
         ConfigKey::HudBackgroundOpacity => 11,
+        ConfigKey::StartAtLogin => 12,
     }
 }
 
@@ -180,6 +182,7 @@ pub fn tag_to_config_key(tag: isize) -> Option<ConfigKey> {
         9 => Some(ConfigKey::HudImageMaxHeight),
         10 => Some(ConfigKey::Language),
         11 => Some(ConfigKey::HudBackgroundOpacity),
+        12 => Some(ConfigKey::StartAtLogin),
         _ => None,
     }
 }
@@ -199,7 +202,7 @@ mod tests {
     #[test]
     fn tag_to_config_key_rejects_unknown_tags() {
         assert_eq!(tag_to_config_key(-1), None);
-        assert_eq!(tag_to_config_key(12), None);
+        assert_eq!(tag_to_config_key(13), None);
         assert_eq!(tag_to_config_key(9999), None);
     }
 }

--- a/src/settings_window/rows.rs
+++ b/src/settings_window/rows.rs
@@ -911,6 +911,7 @@ pub(super) unsafe fn add_login_item_row(
     );
     let () = msg_send![toggle, setFrame: toggle_rect];
     let () = msg_send![toggle, setState: login_item_control_state(enabled)];
+    let () = msg_send![toggle, setTag: config_key_to_tag(ConfigKey::StartAtLogin)];
     let () = msg_send![toggle, setTarget: delegate];
     let () = msg_send![toggle, setAction: sel!(toggleLoginItem:)];
 

--- a/src/settings_window/sync.rs
+++ b/src/settings_window/sync.rs
@@ -3,12 +3,13 @@ use objc2::runtime::AnyObject;
 use objc2_foundation::{NSRange, NSString};
 
 use crate::app::{
-    apply_settings_now, present_hud, show_sample_image_content, show_text_content, AppState,
+    apply_settings_now, apply_start_at_login_if_changed, present_hud, show_sample_image_content,
+    show_text_content, AppState,
 };
 use crate::config::{
     apply_config_file, default_display_settings, hud_emoji_validation_error, load_config_file,
-    save_config_file, set_config_value, settings_to_config_file, ConfigKey, DisplaySettings,
-    LanguageSetting,
+    merge_display_settings, save_config_file, set_config_value, settings_to_config_file,
+    start_at_login_from_config, ConfigKey, DisplaySettings, LanguageSetting,
 };
 use crate::i18n::{self, Lang, Msg};
 use crate::objc_helpers::nsstring_to_string;
@@ -154,14 +155,14 @@ pub unsafe fn sync_controls_from_settings(
     set_emoji_field(controls, &settings.hud_emoji);
 }
 
-/// ログイン項目トグルの表示を実際の LaunchAgent の状態に合わせる。
-/// ウィンドウを開くたびに呼び、ファイル外（Finder 等）での変更との食い違いを防ぐ。
-/// `toggleLoginItem:` が `enable`/`disable` に失敗したときの巻き戻しにも使う。
+/// ログイン項目トグルの表示を `start_at_login` に合わせる。下書きモデルの対象外の
+/// ため、ウィンドウを開くたび・ファイル監視の再読み込み・`toggleLoginItem:` が
+/// `enable`/`disable` に失敗したときの巻き戻しの各経路で、呼び出し側から実効値を渡す。
 ///
 /// # Safety
 /// AppKit のメインスレッドから呼ぶこと。
-pub unsafe fn sync_login_item_toggle(controls: &SettingsControls) {
-    let state = login_item_control_state(crate::login_item::is_enabled());
+pub unsafe fn sync_login_item_toggle(controls: &SettingsControls, start_at_login: bool) {
+    let state = login_item_control_state(start_at_login);
     let () = msg_send![controls.login_item_toggle, setState: state];
 }
 
@@ -484,7 +485,8 @@ unsafe fn apply_language_setting_change(state: &mut AppState, sender: *mut AnyOb
 ///
 /// 組み直しに `display_settings_from_file` を使うのは、`language` だけ差し替えると
 /// 外部エディタでの変更を取り込まないまま `config_mtime` だけ進んでしまい、
-/// ファイル監視がその変更を二度と拾わなくなるため。
+/// ファイル監視がその変更を二度と拾わなくなるため。`start_at_login` は読んだ値を
+/// `apply_start_at_login_if_changed` へ渡して同じ理由で反映する。
 ///
 /// 副作用として、ファイルに保存していない状態は捨てられる。「お試し表示」で下書きを
 /// HUD に当てている最中に言語を切り替えると、HUD はファイルの値に戻る。
@@ -496,11 +498,13 @@ unsafe fn save_language_setting(
         return Err("config path is not resolved; cannot save language setting".to_string());
     };
     let (mut config, _) = load_config_file(&path).map_err(|error| error.to_string())?;
+    let start_at_login = start_at_login_from_config(&config);
     set_config_value(&mut config, ConfigKey::Language, raw).map_err(|error| error.to_string())?;
     save_config_file(&path, &config).map_err(|error| error.to_string())?;
     state.config_mtime = std::fs::metadata(&path)
         .ok()
         .and_then(|m| m.modified().ok());
+    apply_start_at_login_if_changed(state, start_at_login);
 
     crate::app::display_settings_from_file(&path).map_err(|error| error.to_string())
 }
@@ -604,6 +608,10 @@ pub unsafe fn preview_settings(this: &AnyObject, state: &mut AppState) {
 /// 下書きを設定ファイルへ保存し、HUD に適用する。`config_mtime` を保存後のファイルの mtime に
 /// 更新し、直後のファイル監視ポーリングによる二重適用を防ぐ。
 ///
+/// 保存するのは `display` セクションだけ。丸ごと上書きすると、下書きの対象外である
+/// `start_at_login` が下書きの既定値で塗り潰される。既存の設定ファイルを読めなければ、
+/// 読めなかったファイルを上書きして `start_at_login` 等を消さないよう保存を中止する。
+///
 /// # Safety
 /// - `APP_STATE` をロックしないこと（呼び出し側が既にロックを保持している）。
 /// - AppKit のメインスレッドから呼ぶこと。
@@ -615,7 +623,17 @@ pub unsafe fn save_settings(state: &mut AppState) -> bool {
         return false;
     };
 
-    let config = settings_to_config_file(state.settings_controls.draft.clone());
+    let (config, _) = match load_config_file(&path) {
+        Ok(result) => result,
+        Err(error) => {
+            eprintln!("warning: {error}; not saving settings");
+            return false;
+        }
+    };
+    // 下書きの対象外のキーも、ファイルの手編集で新しい値を持っているかもしれない。
+    // merge_display_settings が draft の display で上書きする前に読んでおく。
+    let start_at_login = start_at_login_from_config(&config);
+    let config = merge_display_settings(config, state.settings_controls.draft.clone());
     if let Err(error) = save_config_file(&path, &config) {
         eprintln!("warning: {error}");
         return false;
@@ -623,6 +641,7 @@ pub unsafe fn save_settings(state: &mut AppState) -> bool {
 
     let draft = state.settings_controls.draft.clone();
     apply_settings_now(state, draft);
+    apply_start_at_login_if_changed(state, start_at_login);
     state.config_mtime = std::fs::metadata(&path)
         .ok()
         .and_then(|m| m.modified().ok());
@@ -684,6 +703,7 @@ fn control_for_key(controls: &SettingsControls, key: ConfigKey) -> *mut AnyObjec
         ConfigKey::HudBackgroundOpacity => controls.hud_background_opacity_slider,
         ConfigKey::HudEmoji => controls.hud_emoji_field,
         ConfigKey::Language => controls.language_popup,
+        ConfigKey::StartAtLogin => controls.login_item_toggle,
     }
 }
 
@@ -714,6 +734,8 @@ unsafe fn raw_value_for_key(key: ConfigKey, control: *mut AnyObject) -> Option<S
             let value: *mut AnyObject = msg_send![control, stringValue];
             nsstring_to_string(value)
         }
+        // 自動起動トグルは専用の toggleLoginItem: を持ち、この汎用パスからは呼ばれない
+        ConfigKey::StartAtLogin => None,
     }
 }
 
@@ -774,6 +796,9 @@ unsafe fn resync_controls_after_apply(
         ConfigKey::HudEmoji => {}
         // 言語は下書きモデルの対象外で、保存の成否にかかわらず再同期する対象が無い。
         ConfigKey::Language => {}
+        // 自動起動も下書きモデルの対象外（専用の toggleLoginItem: が設定ファイルへ保存し、
+        // plist はその派生物として合わせる）。
+        ConfigKey::StartAtLogin => {}
     }
 }
 


### PR DESCRIPTION
## 背景

自動起動が有効かどうかの記録は LaunchAgent の plist の有無だけで、plist が外から消えると設定ごと失われる。何も表示されないため、次のログインで起動しないことで初めて気づく。plist は手で消した場合にも、他のツールが触った場合にも消える。

## 変更内容

- 設定ファイル: `[startup] start_at_login` を足し、そちらを正とする。plist はこの値から書き出す
- 起動時: 設定と plist を突き合わせ、食い違えば plist を設定に合わせる
- ファイル監視: 手で書き換えたときも再読み込みで LaunchAgent に反映する
- 設定ウィンドウ: トグルと自動起動の確認ダイアログは設定ファイルへの保存が先で、成功したときだけ plist を操作する。設定ファイルを読めないときは保存を中止する
- CLI: `--config-show` に `start_at_login` を出す

## 仕様の注意点

- 設定に値が無い利用者は、plist が実在するときだけ `true` を書き戻す。plist が無ければ設定ファイルを作らない
- インストール済みの `.app` から起動していないときは plist を新規作成せず、警告だけ出す。開発ビルドのパスを焼き付けると次のビルドで自動起動が止まるため。`.app` ではない形で入れていて plist を消された場合は復活しない
- plist の操作に失敗しても設定ファイルの値は残る

## 確認

- `cargo test`（156 件）
- `./scripts/visual_regression.sh`（全ケース ok）
- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`
- `./scripts/build_app_bundle.sh`
- 実機での plist の書き出しは未確認

## 関連リンク

- Closes #50
